### PR TITLE
Don't emit ANSI colour escape sequences when output is not a tty

### DIFF
--- a/utest.h
+++ b/utest.h
@@ -697,17 +697,15 @@ UTEST_WEAK int utest_main(int argc, const char *const argv[]) {
   const char *filter = 0;
   uint64_t ran_tests = 0;
 
-  enum colours {
-    RESET,
-    GREEN,
-    RED,
-  };
+  enum colours { RESET, GREEN, RED };
 
   const int use_colours = UTEST_COLOUR_OUTPUT();
-  const char *colours[] = {use_colours ? "\033[0m" : "",
-                           use_colours ? "\033[32m" : "",
-                           use_colours ? "\033[31m" : ""};
-
+  const char *colours[] = {"\033[0m", "\033[32m", "\033[31m"};
+  if (!use_colours) {
+    for (index = 0; index < sizeof colours / sizeof colours[0]; index++) {
+      colours[index] = "";
+    }
+  }
   /* loop through all arguments looking for our options */
   for (index = 1; index < UTEST_CAST(size_t, argc); index++) {
     const char help_str[] = "--help";

--- a/utest.h
+++ b/utest.h
@@ -155,7 +155,20 @@
 #endif
 
 #ifdef _WIN32
+#ifdef _MSC_VER
+/*
+    io.h contains definitions for some structures with natural padding. This is
+    uninteresting, but for some reason MSVC's behaviour is to warn about
+    including this system header. That *is* interesting
+*/
+#pragma warning(disable : 4820)
+#pragma warning(push, 1)
+#endif
 #include <io.h>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
 #define UTEST_COLOUR_OUTPUT() (_isatty(_fileno(stdout)))
 #else
 #include <unistd.h>

--- a/utest.h
+++ b/utest.h
@@ -154,7 +154,6 @@
 #define UTEST_EXTERN extern
 #endif
 
-#ifdef _WIN32
 #ifdef _MSC_VER
 /*
     io.h contains definitions for some structures with natural padding. This is
@@ -163,12 +162,8 @@
 */
 #pragma warning(disable : 4820)
 #pragma warning(push, 1)
-#endif
 #include <io.h>
-#ifdef _MSC_VER
 #pragma warning(pop)
-#endif
-
 #define UTEST_COLOUR_OUTPUT() (_isatty(_fileno(stdout)))
 #else
 #include <unistd.h>


### PR DESCRIPTION
When piping the output of utest.h into a file or pipe the default
behaviour should be to omit colour formatting as these output devices
are non-interactive and colour output confounds parsing.

In a future patch I'd like to add support to make this optional a'la

git diff --color=<auto|always|never> or gcc's
`-fdiagnostics-color=<auto|always|never>`

However, this should be sufficient for now.