### PR TITLE
Disable warnings about generated spectre mitigations

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,7 +46,7 @@ elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
   )
 elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
   set_source_files_properties(main.c test.c PROPERTIES
-    COMPILE_FLAGS "/Wall /WX /wd4514"
+    COMPILE_FLAGS "/Wall /WX /wd4514 /wd5045"
   )
 else()
   message(WARNING "Unknown compiler '${CMAKE_C_COMPILER_ID}'!")
@@ -62,7 +62,7 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   )
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   set_source_files_properties(test.cpp PROPERTIES
-    COMPILE_FLAGS "/Wall /WX /wd4514"
+    COMPILE_FLAGS "/Wall /WX /wd4514 /wd5045"
   )
 else()
   message(WARNING "Unknown compiler '${CMAKE_C_COMPILER_ID}'!")


### PR DESCRIPTION
On newer versions of MSVC, the compiler warns at `/Wall` if it will
generate a FENCE to mitigate against spectre

https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5045?view=vs-2019

This breaks testing, and is uninteresting for our purposes.