### PR TITLE
Support the type printer for C11 compilers

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,7 +24,7 @@
 # For more information, please refer to <http://unlicense.org/>
 
 project(utest)
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.1.3)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
 
@@ -34,9 +34,16 @@ add_executable(utest_test
   test.c
   test.cpp
   stdint_include.c
+  type_printers.c
+  type_printers.cpp
 )
 
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+  list(FIND CMAKE_C_COMPILE_FEATURES c_std_11 IDX)
+  if (${IDX} GREATER -1)
+    set_source_files_properties(type_printers.c PROPERTIES
+      COMPILE_FLAGS "-std=gnu11")
+  endif()
   set_source_files_properties(main.c test.c PROPERTIES
     COMPILE_FLAGS "-Wall -Wextra -Werror -std=gnu89"
   )

--- a/test/type_printers.c
+++ b/test/type_printers.c
@@ -1,0 +1,2 @@
+#include "utest.h"
+#include "type_printers.inc"

--- a/test/type_printers.cpp
+++ b/test/type_printers.cpp
@@ -1,0 +1,2 @@
+#include "utest.h"
+#include "type_printers.inc"

--- a/test/type_printers.inc
+++ b/test/type_printers.inc
@@ -1,0 +1,54 @@
+#include <limits.h>
+
+#if __STDC_VERSION__ >= 201112L || __cplusplus >= 201103L
+
+#ifdef __cplusplus
+UTEST(type_printers, cpp) {
+#elif defined(UTEST_OVERLOADABLE)
+UTEST(type_printers, overloadable) {
+#elif __STDC_VERSION__
+UTEST(type_printers, stdc) {
+#else
+#error
+#endif
+
+#define TO_S_X(val) #val
+#define S(val) TO_S_X(val)
+  FILE *old = utest_state.output;
+  FILE *out = tmpfile();
+  ASSERT_TRUE(!!out);
+  utest_state.output = out;
+
+  int i = INT_MIN;
+  long l = LONG_MIN;
+  long long ll = LLONG_MIN;
+  unsigned u = UINT_MAX;
+  unsigned long ul = ULONG_MAX;
+  unsigned long long ull = ULLONG_MAX;
+  float f = 0.f;
+  double d = 0.;
+  long double ld = 0.l;
+  utest_type_printer(i);
+  utest_type_printer(l);
+  utest_type_printer(ll);
+  utest_type_printer(u);
+  utest_type_printer(ul);
+  utest_type_printer(ull);
+  utest_type_printer(f);
+  utest_type_printer(d);
+  utest_type_printer(ld);
+
+  char expected[1024] = {0};
+  size_t expected_len =
+      UTEST_SNPRINTF(expected, sizeof expected - 1, "%d%ld%lld%u%lu%llu%f%f%Lf",
+                     i, l, ll, u, ul, ull, f, d, ld);
+  fflush(out);
+  rewind(out);
+  char buf[1024] = {'\0'};
+  size_t n = fread(buf, 1, sizeof buf, out);
+  fclose(out);
+  utest_state.output = old;
+  ASSERT_EQ(n, expected_len);
+  ASSERT_STREQ(buf, expected);
+}
+#endif

--- a/utest.h
+++ b/utest.h
@@ -297,9 +297,9 @@ UTEST_WEAK UTEST_OVERLOADABLE void utest_type_printer(long unsigned int i) {
 
 /*
    long long is a c++11 extension
-   TODO: grok for c++11 version here
 */
-#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) ||              \
+    defined(__cplusplus) && (__cplusplus >= 201103L)
 UTEST_WEAK UTEST_OVERLOADABLE void utest_type_printer(long long int i);
 UTEST_WEAK UTEST_OVERLOADABLE void utest_type_printer(long long int i) {
   UTEST_PRINTF("%lld", i);
@@ -311,6 +311,22 @@ utest_type_printer(long long unsigned int i) {
   UTEST_PRINTF("%llu", i);
 }
 #endif
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#define utest_type_printer(val)                                                \
+  UTEST_PRINTF(_Generic((val), int                                             \
+                        : "%d", long                                           \
+                        : "%ld", long long                                     \
+                        : "%lld", unsigned                                     \
+                        : "%u", unsigned long                                  \
+                        : "%lu", unsigned long long                            \
+                        : "%llu", float                                        \
+                        : "%f", double                                         \
+                        : "%f", long double                                    \
+                        : "%Lf", default                                       \
+                        : _Generic((val - val), ptrdiff_t                      \
+                                   : "%p", default                             \
+                                   : "undef")),                                \
+               (val))
 #else
 /*
    we don't have the ability to print the values we got, so we create a macro


### PR DESCRIPTION
`_Generic` allows us to select the value based on the type of the
expression, which means we don't need to support function overloading,
and means failing expressions print properly in gcc