### PR TITLE
Keep symbols during whole program optimization (WPO).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ script:
   - cmake -DCMAKE_BUILD_TYPE=$CONFIGURATION ../test
   - make
   - ./utest_test
+  - ./utest_test_wpo

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,8 @@ environment:
     - VSVERSION: Visual Studio 14 2015
     - VSVERSION: Visual Studio 15 2017
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - VSVERSION: Visual Studio 16 2019
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
 
 platform:
   - Win32
@@ -32,10 +34,13 @@ configuration:
 build_script:
   - md build
   - cd build
-  - if "%PLATFORM%"=="x64" cmake -G "%VSVERSION% Win64" ../test
-  - if "%PLATFORM%"=="Win32" cmake -G "%VSVERSION%" ../test
+  - if NOT "%VSVERSION%"=="Visual Studio 16 2019" if "%PLATFORM%"=="x64" cmake -G "%VSVERSION% Win64" ../test
+  - if NOT "%VSVERSION%"=="Visual Studio 16 2019" if "%PLATFORM%"=="Win32" cmake -G "%VSVERSION%" ../test
+  - if "%VSVERSION%"=="Visual Studio 16 2019" cmake -G "%VSVERSION%" -A "%PLATFORM%" ../test
   - msbuild /m /p:Configuration="%CONFIGURATION%" /p:Platform="%PLATFORM%" utest.sln
   - copy %CONFIGURATION%\utest_test.exe utest_test.exe
+  - copy %CONFIGURATION%\utest_test_wpo.exe utest_test_wpo.exe
 
 test_script:
   - utest_test.exe
+  - utest_test_wpo.exe

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,17 +28,6 @@ cmake_minimum_required(VERSION 3.1.3)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
 
-add_executable(utest_test
-  ../utest.h
-  main.c
-  test.c
-  test.cpp
-  test11.cpp
-  stdint_include.c
-  type_printers.c
-  type_printers.cpp
-)
-
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
   list(FIND CMAKE_C_COMPILE_FEATURES c_std_11 IDX)
   if (${IDX} GREATER -1)
@@ -90,4 +79,32 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   )
 else()
   message(WARNING "Unknown compiler '${CMAKE_C_COMPILER_ID}'!")
+endif()
+
+add_executable(utest_test
+  ../utest.h
+  main.c
+  test.c
+  test.cpp
+  test11.cpp
+  stdint_include.c
+  type_printers.c
+  type_printers.cpp
+)
+
+add_executable(utest_test_wpo
+  ../utest.h
+  main.c
+  test.c
+  test.cpp
+  test11.cpp
+  stdint_include.c
+  type_printers.c
+  type_printers.cpp
+)
+
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+  target_compile_options(utest_test_wpo PRIVATE "$<$<CONFIG:RELEASE>:/GL>")
+  target_link_options(utest_test_wpo PRIVATE "$<$<CONFIG:RELEASE>:/LTCG>")
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,8 +103,15 @@ add_executable(utest_test_wpo
   type_printers.cpp
 )
 
-
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+  target_compile_options(utest_test_wpo PRIVATE "$<$<CONFIG:RELEASE>:-flto>")
+  target_link_libraries(utest_test_wpo PRIVATE "$<$<CONFIG:RELEASE>:-flto>")
+elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+  target_compile_options(utest_test_wpo PRIVATE "$<$<CONFIG:RELEASE>:-flto>")
+  target_link_libraries(utest_test_wpo PRIVATE "$<$<CONFIG:RELEASE>:-flto>")
+elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
   target_compile_options(utest_test_wpo PRIVATE "$<$<CONFIG:RELEASE>:/GL>")
   target_link_options(utest_test_wpo PRIVATE "$<$<CONFIG:RELEASE>:/LTCG>")
+else()
+  message(WARNING "Unknown compiler '${CMAKE_C_COMPILER_ID}'!")
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,15 +103,7 @@ add_executable(utest_test_wpo
   type_printers.cpp
 )
 
-if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
-  target_compile_options(utest_test_wpo PRIVATE "$<$<CONFIG:RELEASE>:-flto>")
-  target_link_libraries(utest_test_wpo PRIVATE "$<$<CONFIG:RELEASE>:-flto>")
-elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
-  target_compile_options(utest_test_wpo PRIVATE "$<$<CONFIG:RELEASE>:-flto>")
-  target_link_libraries(utest_test_wpo PRIVATE "$<$<CONFIG:RELEASE>:-flto>")
-elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   target_compile_options(utest_test_wpo PRIVATE "$<$<CONFIG:RELEASE>:/GL>")
   target_link_options(utest_test_wpo PRIVATE "$<$<CONFIG:RELEASE>:/LTCG>")
-else()
-  message(WARNING "Unknown compiler '${CMAKE_C_COMPILER_ID}'!")
 endif()

--- a/utest.h
+++ b/utest.h
@@ -112,10 +112,24 @@ typedef uint64_t utest_uint64_t;
 #define UTEST_PRIu64 "I64u"
 #define UTEST_INLINE __forceinline
 
+#if defined(__cplusplus)
+#define UTEST_C_FUNC extern "C"
+#else
+#define UTEST_C_FUNC
+#endif
+
+#if defined(_WIN64)
+#define UTEST_SYMBOL_PREFIX
+#else
+#define UTEST_SYMBOL_PREFIX "_"
+#endif
+
 #pragma section(".CRT$XCU", read)
 #define UTEST_INITIALIZER(f)                                                   \
   static void __cdecl f(void);                                                 \
-  __declspec(allocate(".CRT$XCU")) void(__cdecl * f##_)(void) = f;             \
+  __pragma(comment(linker, "/include:" UTEST_SYMBOL_PREFIX #f "_"));           \
+  UTEST_C_FUNC __declspec(allocate(".CRT$XCU")) void(__cdecl * f##_)(void) =   \
+      f;                                                                       \
   static void __cdecl f(void)
 #else
 #if defined(__linux__)


### PR DESCRIPTION
This commit just uses the `__pragma(comment(linker, "symbol"));` trick
to ensure that the symbol is kept even if whole program optimization
comes along and tries to remove it.

Fixes #31.