### PR TITLE
fix compile error on gcc4.8.5

### DIFF
--- a/utest.h
+++ b/utest.h
@@ -384,7 +384,7 @@ utest_type_printer(long long unsigned int i) {
           _Pragma("clang diagnostic pop")
 /* clang-format on */
 #else
-#define UTEST_AUTO(x) __auto_type
+#define UTEST_AUTO(x) __typeof__(x)
 #endif
 
 #else


### PR DESCRIPTION
CentOS-7.5.1804 gcc.4.8.5
error: unknown type name '__auto_type'

pr was tested on [gcc4.8.5 centos7.5.1804] and  [gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3  Ubuntu 20.04.1 LTS]