### PR TITLE
*_STRNEQ & *_STRNNE no longer assumes input strings are null-terminated, instead user provides the length.

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -59,9 +59,9 @@ UTEST(c, ASSERT_STREQ) { ASSERT_STREQ("foo", "foo"); }
 
 UTEST(c, ASSERT_STRNE) { ASSERT_STRNE("foo", "bar"); }
 
-UTEST(c, ASSERT_STRNEQ) { ASSERT_STRNEQ("foo", "foobar"); }
+UTEST(c, ASSERT_STRNEQ) { ASSERT_STRNEQ("foo", "foobar", strlen("foo")); }
 
-UTEST(c, ASSERT_STRNNE) { ASSERT_STRNNE("foobar", "bar"); }
+UTEST(c, ASSERT_STRNNE) { ASSERT_STRNNE("foo", "barfoo", strlen("foo")); }
 
 UTEST(c, EXPECT_TRUE) { EXPECT_TRUE(1); }
 
@@ -89,9 +89,9 @@ UTEST(c, EXPECT_STREQ) { EXPECT_STREQ("foo", "foo"); }
 
 UTEST(c, EXPECT_STRNE) { EXPECT_STRNE("foo", "bar"); }
 
-UTEST(c, EXPECT_STRNEQ) { EXPECT_STRNEQ("foo", "foobar"); }
+UTEST(c, EXPECT_STRNEQ) { EXPECT_STRNEQ("foo", "foobar", strlen("foo")); }
 
-UTEST(c, EXPECT_STRNNE) { EXPECT_STRNNE("foobar", "bar"); }
+UTEST(c, EXPECT_STRNNE) { EXPECT_STRNNE("foo", "barfoo", strlen("foo")); }
 
 UTEST(c, no_double_eval) {
   int i = 0;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -56,9 +56,9 @@ UTEST(cpp, ASSERT_STREQ) { ASSERT_STREQ("foo", "foo"); }
 
 UTEST(cpp, ASSERT_STRNE) { ASSERT_STRNE("foo", "bar"); }
 
-UTEST(cpp, ASSERT_STRNEQ) { ASSERT_STRNEQ("foo", "foobar"); }
+UTEST(cpp, ASSERT_STRNEQ) { ASSERT_STRNEQ("foo", "foobar", strlen("foo")); }
 
-UTEST(cpp, ASSERT_STRNNE) { ASSERT_STRNNE("foobar", "bar"); }
+UTEST(cpp, ASSERT_STRNNE) { ASSERT_STRNNE("foo", "barfoo", strlen("foo")); }
 
 UTEST(cpp, EXPECT_TRUE) { EXPECT_TRUE(1); }
 
@@ -86,9 +86,9 @@ UTEST(cpp, EXPECT_STREQ) { EXPECT_STREQ("foo", "foo"); }
 
 UTEST(cpp, EXPECT_STRNE) { EXPECT_STRNE("foo", "bar"); }
 
-UTEST(cpp, EXPECT_STRNEQ) { EXPECT_STRNEQ("foo", "foobar"); }
+UTEST(cpp, EXPECT_STRNEQ) { EXPECT_STRNEQ("foo", "foobar", strlen("foo")); }
 
-UTEST(cpp, EXPECT_STRNNE) { EXPECT_STRNNE("foobar", "bar"); }
+UTEST(cpp, EXPECT_STRNNE) { EXPECT_STRNNE("foo", "barfoo", strlen("foo")); }
 
 UTEST(cpp, no_double_eval) {
   int i = 0;

--- a/test/test11.cpp
+++ b/test/test11.cpp
@@ -56,9 +56,9 @@ UTEST(cpp11, ASSERT_STREQ) { ASSERT_STREQ("foo", "foo"); }
 
 UTEST(cpp11, ASSERT_STRNE) { ASSERT_STRNE("foo", "bar"); }
 
-UTEST(cpp11, ASSERT_STRNEQ) { ASSERT_STRNEQ("foo", "foobar"); }
+UTEST(cpp11, ASSERT_STRNEQ) { ASSERT_STRNEQ("foo", "foobar", strlen("foo")); }
 
-UTEST(cpp11, ASSERT_STRNNE) { ASSERT_STRNNE("foobar", "bar"); }
+UTEST(cpp11, ASSERT_STRNNE) { ASSERT_STRNNE("foo", "barfoo", strlen("foo")); }
 
 UTEST(cpp11, EXPECT_TRUE) { EXPECT_TRUE(1); }
 
@@ -86,9 +86,9 @@ UTEST(cpp11, EXPECT_STREQ) { EXPECT_STREQ("foo", "foo"); }
 
 UTEST(cpp11, EXPECT_STRNE) { EXPECT_STRNE("foo", "bar"); }
 
-UTEST(cpp11, EXPECT_STRNEQ) { EXPECT_STRNEQ("foo", "foobar"); }
+UTEST(cpp11, EXPECT_STRNEQ) { EXPECT_STRNEQ("foo", "foobar", strlen("foo")); }
 
-UTEST(cpp11, EXPECT_STRNNE) { EXPECT_STRNNE("foobar", "bar"); }
+UTEST(cpp11, EXPECT_STRNNE) { EXPECT_STRNNE("foo", "barfoo", strlen("foo")); }
 
 UTEST(cpp11, no_double_eval) {
   int i = 0;

--- a/utest.h
+++ b/utest.h
@@ -495,19 +495,19 @@ utest_type_printer(long long unsigned int i) {
     *utest_result = 1;                                                         \
   }
 
-#define EXPECT_STRNEQ(x, y)                                                    \
-  if (0 != UTEST_STRNCMP(x, y, strlen(x))) {                                   \
+#define EXPECT_STRNEQ(x, y, n)                                                 \
+  if (0 != UTEST_STRNCMP(x, y, n)) {                                           \
     UTEST_PRINTF("%s:%u: Failure\n", __FILE__, __LINE__);                      \
-    UTEST_PRINTF("  Expected : \"%s\"\n", x);                                  \
-    UTEST_PRINTF("    Actual : \"%s\"\n", y);                                  \
+    UTEST_PRINTF("  Expected : \"%.*s\"\n", (int)n, x);                        \
+    UTEST_PRINTF("    Actual : \"%.*s\"\n", (int)n, y);                        \
     *utest_result = 1;                                                         \
   }
 
-#define EXPECT_STRNNE(x, y)                                                    \
-  if (0 == UTEST_STRNCMP(x, y, strlen(x))) {                                   \
+#define EXPECT_STRNNE(x, y, n)                                                 \
+  if (0 == UTEST_STRNCMP(x, y, n)) {                                           \
     UTEST_PRINTF("%s:%u: Failure\n", __FILE__, __LINE__);                      \
-    UTEST_PRINTF("  Expected : \"%s\"\n", x);                                  \
-    UTEST_PRINTF("    Actual : \"%s\"\n", y);                                  \
+    UTEST_PRINTF("  Expected : \"%.*s\"\n", (int)n, x);                        \
+    UTEST_PRINTF("    Actual : \"%.*s\"\n", (int)n, y);                        \
     *utest_result = 1;                                                         \
   }
 
@@ -604,20 +604,20 @@ utest_type_printer(long long unsigned int i) {
     return;                                                                    \
   }
 
-#define ASSERT_STRNEQ(x, y)                                                    \
-  if (0 != UTEST_STRNCMP(x, y, strlen(x))) {                                   \
+#define ASSERT_STRNEQ(x, y, n)                                                 \
+  if (0 != UTEST_STRNCMP(x, y, n)) {                                           \
     UTEST_PRINTF("%s:%u: Failure\n", __FILE__, __LINE__);                      \
-    UTEST_PRINTF("  Expected : \"%s\"\n", x);                                  \
-    UTEST_PRINTF("    Actual : \"%s\"\n", y);                                  \
+    UTEST_PRINTF("  Expected : \"%.*s\"\n", (int)n, x);                        \
+    UTEST_PRINTF("    Actual : \"%.*s\"\n", (int)n, y);                        \
     *utest_result = 1;                                                         \
     return;                                                                    \
   }
 
-#define ASSERT_STRNNE(x, y)                                                    \
-  if (0 == UTEST_STRNCMP(x, y, strlen(x))) {                                   \
+#define ASSERT_STRNNE(x, y, n)                                                 \
+  if (0 == UTEST_STRNCMP(x, y, n)) {                                           \
     UTEST_PRINTF("%s:%u: Failure\n", __FILE__, __LINE__);                      \
-    UTEST_PRINTF("  Expected : \"%s\"\n", x);                                  \
-    UTEST_PRINTF("    Actual : \"%s\"\n", y);                                  \
+    UTEST_PRINTF("  Expected : \"%.*s\"\n", (int)n, x);                        \
+    UTEST_PRINTF("    Actual : \"%.*s\"\n", (int)n, y);                        \
     *utest_result = 1;                                                         \
     return;                                                                    \
   }


### PR DESCRIPTION
See issue #45