### PR TITLE
Reset errno between tests

### DIFF
--- a/utest.h
+++ b/utest.h
@@ -62,6 +62,7 @@ typedef uint64_t utest_uint64_t;
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -911,6 +912,7 @@ UTEST_WEAK int utest_main(int argc, const char *const argv[]) {
     }
 
     ns = utest_ns();
+    errno = 0;
     utest_state.tests[index].func(&result, utest_state.tests[index].index);
     ns = utest_ns() - ns;
 


### PR DESCRIPTION
This is helpful for separating user test cases from each other, and also
fixes a bug wherby `UTEST_COLOUR_OUTPUT` implicity sets `errno` if the
standard streams are not connected to a tty. e.g.

```shell-session
$ cat <<EOF > test.c

UTEST(errno, not_set)
{
    ASSERT_EQ(errno, 0);
}

UTEST_MAIN();
EOF

$ cc test.c
$ ./a.out
[==========] Running 1 test cases.
[ RUN      ] errno.not_set
[       OK ] errno.not_set (1747ns)
[==========] 1 test cases ran.
[  PASSED  ] 1 tests.
$ ./a.out | cat
[==========] Running 1 test cases.
[ RUN      ] errno.not_set
test.c:6: Failure
  Expected : 25
    Actual : 0
[  FAILED  ] errno.not_set (4892ns)
[==========] 1 test cases ran.
[  PASSED  ] 0 tests.
[  FAILED  ] 1 tests, listed below:
[  FAILED  ] errno.not_set
```