### PR TITLE
- fixed problem with compilation on Windows 7 / VS2015

### DIFF
--- a/test/test.cpp
+++ b/test/test.cpp
@@ -26,6 +26,10 @@
 #include "utest.h"
 
 #ifdef _MSC_VER
+// test will including <Windows.h> mess up the compilation
+#pragma warning(push, 0)
+#include <Windows.h>
+#pragma warning(pop)
 // disable 'conditional expression is constant' - our examples below use this!
 #pragma warning(disable : 4127)
 #endif

--- a/utest.h
+++ b/utest.h
@@ -72,6 +72,16 @@ typedef uint64_t utest_uint64_t;
 #endif
 
 #if defined(_MSC_VER)
+// define UTEST_USE_OLD_QPC before #include "utest.h" to use old QueryPerformanceCounter
+#ifndef UTEST_USE_OLD_QPC
+#pragma warning(push, 0)
+#include <Windows.h>
+#pragma warning(pop)
+
+typedef LARGE_INTEGER utest_large_integer;
+#else 
+//use old QueryPerformanceCounter definitions (not sure is this needed in some edge cases or not)
+//on Win7 with VS2015 these extern declaration cause "second C linkage of overloaded function not allowed" error
 typedef union {
   struct {
     unsigned long LowPart;
@@ -88,6 +98,7 @@ UTEST_C_FUNC __declspec(dllimport) int __stdcall QueryPerformanceCounter(
     utest_large_integer *);
 UTEST_C_FUNC __declspec(dllimport) int __stdcall QueryPerformanceFrequency(
     utest_large_integer *);
+#endif
 #elif defined(__linux__)
 
 /*


### PR DESCRIPTION
Today I've run into problem when tried to run some tests on Win 7 and these pull request address that problem (and adds `#include <Windows.h>` to test.cpp in order to verify the fix)

However, please take these changes with grain of salt - I haven't verified that these changes does not break anything on newer MSVC compilers.

Here are detailed information about compiler in my case:

```
$ cmake .
-- Building for: Visual Studio 14 2015
-- The C compiler identification is MSVC 19.0.23918.0
-- The CXX compiler identification is MSVC 19.0.23918.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done

```