### PR TITLE
Fix -Wreturn-type warning in mingw gcc.

### DIFF
--- a/utest.h
+++ b/utest.h
@@ -263,6 +263,7 @@ static UTEST_INLINE utest_int64_t utest_ns(void) {
 #elif __EMSCRIPTEN__	                                    
 	return emscripten_performance_now()*1000000.0; 
 #endif
+  return 0;
 }
 
 typedef void (*utest_testcase_t)(int *, size_t);


### PR DESCRIPTION
mingw gcc gives me this warning:
```
utest.h:266:1: warning: no return statement in function returning non-void [-Wreturn-type]
  266 | }
      | ^
```
This fixes it.