### PR TITLE
Fixed Readme ASSERT_STRNE using the wrong code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,8 +333,8 @@ Asserts that the strings x and y are not equal.
 UTEST(foo, bar) {
   char* a = "foo";
   char* b = "bar";
-  ASSERT_STREQ(a, b); // pass!
-  ASSERT_STREQ(a, a); // fail!
+  ASSERT_STRNE(a, b); // pass!
+  ASSERT_STRNE(a, a); // fail!
 }
 ```
 


### PR DESCRIPTION
Noticed this while reading the documentation thought I would jump in and fix it. 