### PR TITLE
Add support for assert/expect with epsilon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,20 @@ UTEST(foo, bar) {
 }
 ```
 
+### ASSERT_NEAR(x, y, epsilon)
+
+Asserts that the floating-point values x and y are within epsilon distance of
+each other.
+
+```c
+UTEST(foo, bar) {
+  float a = 42.0f;
+  float b = 42.01f;
+  ASSERT_NEAR(a, b, 0.01f);  // pass!
+  ASSERT_NEAR(a, b, 0.001f); // fail!
+}
+```
+
 ### EXPECT_TRUE(x)
 
 Expects that x evaluates to true (i.e. non-zero).
@@ -544,6 +558,20 @@ UTEST(foo, bar) {
   char* b = "bar";
   EXPECT_STRNNE(a, b); // pass!
   EXPECT_STRNNE(a, a); // fail!
+}
+```
+
+### EXPECT_NEAR(x, y, epsilon)
+
+Expects that the floating-point values x and y are within epsilon distance of
+each other.
+
+```c
+UTEST(foo, bar) {
+  float a = 42.0f;
+  float b = 42.01f;
+  EXPECT_NEAR(a, b, 0.01f);  // pass!
+  EXPECT_NEAR(a, b, 0.001f); // fail!
 }
 ```
 

--- a/test/test.c
+++ b/test/test.c
@@ -237,3 +237,10 @@ UTEST(c, VoidPtr) {
 static const int data[4] = {42, 13, 6, -53};
 
 UTEST(c, Array) { EXPECT_NE(data, data + 1); }
+
+UTEST(c, Near) {
+  float a = 42.0f;
+  float b = 42.01f;
+  EXPECT_NEAR(a, b, 0.01f);
+  ASSERT_NEAR(a, b, 0.01f);
+}

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -233,3 +233,10 @@ UTEST(cpp, Ptr) {
 static const int data[4] = {42, 13, 6, -53};
 
 UTEST(cpp, Array) { EXPECT_NE(data, data + 1); }
+
+UTEST(cpp, Near) {
+  float a = 42.0f;
+  float b = 42.01f;
+  EXPECT_NEAR(a, b, 0.01f);
+  ASSERT_NEAR(a, b, 0.01f);
+}

--- a/test/test11.c
+++ b/test/test11.c
@@ -229,3 +229,10 @@ UTEST(c11, VoidPtr) {
 static const int data[4] = {42, 13, 6, -53};
 
 UTEST(c11, Array) { EXPECT_NE(data, data + 1); }
+
+UTEST(c11, Near) {
+  float a = 42.0f;
+  float b = 42.01f;
+  EXPECT_NEAR(a, b, 0.01f);
+  ASSERT_NEAR(a, b, 0.01f);
+}

--- a/test/test11.cpp
+++ b/test/test11.cpp
@@ -234,3 +234,10 @@ UTEST(cpp11, VoidPtr) {
 static const int data[4] = {42, 13, 6, -53};
 
 UTEST(cpp11, Array) { EXPECT_NE(data, data + 1); }
+
+UTEST(cpp11, Near) {
+  float a = 42.0f;
+  float b = 42.01f;
+  EXPECT_NEAR(a, b, 0.01f);
+  ASSERT_NEAR(a, b, 0.01f);
+}

--- a/test/test99.c
+++ b/test/test99.c
@@ -229,3 +229,10 @@ UTEST(c99, VoidPtr) {
 static const int data[4] = {42, 13, 6, -53};
 
 UTEST(c99, Array) { EXPECT_NE(data, data + 1); }
+
+UTEST(c99, Near) {
+  float a = 42.0f;
+  float b = 42.01f;
+  EXPECT_NEAR(a, b, 0.01f);
+  ASSERT_NEAR(a, b, 0.01f);
+}

--- a/utest.h
+++ b/utest.h
@@ -661,6 +661,19 @@ utest_type_printer(long long unsigned int i) {
   while (0)                                                                    \
   UTEST_SURPRESS_WARNING_END
 
+#define EXPECT_NEAR(x, y, epsilon)                                             \
+  UTEST_SURPRESS_WARNING_BEGIN do {                                            \
+    if (utest_fabs(UTEST_CAST(double, x) - UTEST_CAST(double, y)) >            \
+        UTEST_CAST(double, epsilon)) {                                         \
+      UTEST_PRINTF("%s:%u: Failure\n", __FILE__, __LINE__);                    \
+      UTEST_PRINTF("  Expected : %f\n", UTEST_CAST(double, x));                \
+      UTEST_PRINTF("    Actual : %f\n", UTEST_CAST(double, y));                \
+      *utest_result = 1;                                                       \
+    }                                                                          \
+  }                                                                            \
+  while (0)                                                                    \
+  UTEST_SURPRESS_WARNING_END
+
 #if defined(__clang__)
 #define UTEST_ASSERT(x, y, cond)                                               \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \
@@ -802,6 +815,20 @@ utest_type_printer(long long unsigned int i) {
   while (0)                                                                    \
   UTEST_SURPRESS_WARNING_END
 
+#define ASSERT_NEAR(x, y, epsilon)                                             \
+  UTEST_SURPRESS_WARNING_BEGIN do {                                            \
+    if (utest_fabs(UTEST_CAST(double, x) - UTEST_CAST(double, y)) >            \
+        UTEST_CAST(double, epsilon)) {                                         \
+      UTEST_PRINTF("%s:%u: Failure\n", __FILE__, __LINE__);                    \
+      UTEST_PRINTF("  Expected : %f\n", UTEST_CAST(double, x));                \
+      UTEST_PRINTF("    Actual : %f\n", UTEST_CAST(double, y));                \
+      *utest_result = 1;                                                       \
+      return;                                                                  \
+    }                                                                          \
+  }                                                                            \
+  while (0)                                                                    \
+  UTEST_SURPRESS_WARNING_END
+
 #define UTEST(SET, NAME)                                                       \
   UTEST_EXTERN struct utest_state_s utest_state;                               \
   static void utest_run_##SET##_##NAME(int *utest_result);                     \
@@ -914,6 +941,19 @@ utest_type_printer(long long unsigned int i) {
   }                                                                            \
   void utest_run_##FIXTURE##_##NAME##_##INDEX(int *utest_result,               \
                                               struct FIXTURE *utest_fixture)
+
+UTEST_WEAK
+double utest_fabs(double d);
+UTEST_WEAK
+double utest_fabs(double d) {
+  union {
+    double d;
+    utest_uint64_t u;
+  } both;
+  both.d = d;
+  both.u &= 0x7fffffffffffffffu;
+  return both.d;
+}
 
 UTEST_WEAK
 int utest_should_filter_test(const char *filter, const char *testcase);


### PR DESCRIPTION
This commit adds `ASSERT_NEAR` and `EXPECT_NEAR` to support epsilon aware floating-point checks.

Fixes #91.