### PR TITLE
Try a fix for the `ASSERT_NE` bug.

### DIFF
--- a/utest.h
+++ b/utest.h
@@ -537,8 +537,8 @@ utest_type_printer(long long unsigned int i) {
                     UTEST_AUTO(x) xEval = (x);                                 \
     UTEST_AUTO(y) yEval = (y);                                                 \
     if (!((xEval)cond(yEval))) {                                               \
-      _Pragma("clang diagnostic pop")                                          \
-          UTEST_PRINTF("%s:%u: Failure\n", __FILE__, __LINE__);                \
+      _Pragma("clang diagnostic pop") UTEST_PRINTF(                            \
+          "%s:%u: Failure (Expected " #cond " Actual)\n", __FILE__, __LINE__); \
       UTEST_PRINTF("  Expected : ");                                           \
       utest_type_printer(xEval);                                               \
       UTEST_PRINTF("\n");                                                      \
@@ -556,7 +556,8 @@ utest_type_printer(long long unsigned int i) {
     UTEST_AUTO(x) xEval = (x);                                                 \
     UTEST_AUTO(y) yEval = (y);                                                 \
     if (!((xEval)cond(yEval))) {                                               \
-      UTEST_PRINTF("%s:%u: Failure\n", __FILE__, __LINE__);                    \
+      UTEST_PRINTF("%s:%u: Failure (Expected " #cond " Actual)\n", __FILE__,   \
+                   __LINE__);                                                  \
       UTEST_PRINTF("  Expected : ");                                           \
       utest_type_printer(xEval);                                               \
       UTEST_PRINTF("\n");                                                      \
@@ -572,7 +573,8 @@ utest_type_printer(long long unsigned int i) {
 #define UTEST_EXPECT(x, y, cond)                                               \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \
     if (!((x)cond(y))) {                                                       \
-      UTEST_PRINTF("%s:%u: Failure\n", __FILE__, __LINE__);                    \
+      UTEST_PRINTF("%s:%u: Failure (Expected " #cond " Actual)\n", __FILE__,   \
+                   __LINE__);                                                  \
       *utest_result = 1;                                                       \
     }                                                                          \
   }                                                                            \
@@ -682,8 +684,8 @@ utest_type_printer(long long unsigned int i) {
                     UTEST_AUTO(x) xEval = (x);                                 \
     UTEST_AUTO(y) yEval = (y);                                                 \
     if (!((xEval)cond(yEval))) {                                               \
-      _Pragma("clang diagnostic pop")                                          \
-          UTEST_PRINTF("%s:%u: Failure\n", __FILE__, __LINE__);                \
+      _Pragma("clang diagnostic pop") UTEST_PRINTF(                            \
+          "%s:%u: Failure (Expected " #cond " Actual)\n", __FILE__, __LINE__); \
       UTEST_PRINTF("  Expected : ");                                           \
       utest_type_printer(xEval);                                               \
       UTEST_PRINTF("\n");                                                      \
@@ -702,7 +704,8 @@ utest_type_printer(long long unsigned int i) {
     UTEST_AUTO(x) xEval = (x);                                                 \
     UTEST_AUTO(y) yEval = (y);                                                 \
     if (!((xEval)cond(yEval))) {                                               \
-      UTEST_PRINTF("%s:%u: Failure\n", __FILE__, __LINE__);                    \
+      UTEST_PRINTF("%s:%u: Failure (Expected " #cond " Actual)\n", __FILE__,   \
+                   __LINE__);                                                  \
       UTEST_PRINTF("  Expected : ");                                           \
       utest_type_printer(xEval);                                               \
       UTEST_PRINTF("\n");                                                      \
@@ -719,7 +722,8 @@ utest_type_printer(long long unsigned int i) {
 #define UTEST_ASSERT(x, y, cond)                                               \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \
     if (!((x)cond(y))) {                                                       \
-      UTEST_PRINTF("%s:%u: Failure\n", __FILE__, __LINE__);                    \
+      UTEST_PRINTF("%s:%u: Failure (Expected " #cond " Actual)\n", __FILE__,   \
+                   __LINE__);                                                  \
       *utest_result = 1;                                                       \
       return;                                                                  \
     }                                                                          \

--- a/utest.h
+++ b/utest.h
@@ -537,12 +537,14 @@ utest_type_printer(long long unsigned int i) {
                     UTEST_AUTO(x) xEval = (x);                                 \
     UTEST_AUTO(y) yEval = (y);                                                 \
     if (!((xEval)cond(yEval))) {                                               \
-      _Pragma("clang diagnostic pop") UTEST_PRINTF(                            \
-          "%s:%u: Failure (Expected " #cond " Actual)\n", __FILE__, __LINE__); \
-      UTEST_PRINTF("  Expected : ");                                           \
-      utest_type_printer(xEval);                                               \
-      UTEST_PRINTF("\n");                                                      \
+      _Pragma("clang diagnostic pop")                                          \
+          UTEST_PRINTF("%s:%u: Failure\n", __FILE__, __LINE__);                \
+      UTEST_PRINTF("  Expected : (");                                          \
+      UTEST_PRINTF(#x ") " #cond " (" #y);                                     \
+      UTEST_PRINTF(")\n");                                                     \
       UTEST_PRINTF("    Actual : ");                                           \
+      utest_type_printer(xEval);                                               \
+      UTEST_PRINTF(" vs ");                                                    \
       utest_type_printer(yEval);                                               \
       UTEST_PRINTF("\n");                                                      \
       *utest_result = 1;                                                       \
@@ -556,12 +558,13 @@ utest_type_printer(long long unsigned int i) {
     UTEST_AUTO(x) xEval = (x);                                                 \
     UTEST_AUTO(y) yEval = (y);                                                 \
     if (!((xEval)cond(yEval))) {                                               \
-      UTEST_PRINTF("%s:%u: Failure (Expected " #cond " Actual)\n", __FILE__,   \
-                   __LINE__);                                                  \
-      UTEST_PRINTF("  Expected : ");                                           \
-      utest_type_printer(xEval);                                               \
-      UTEST_PRINTF("\n");                                                      \
+      UTEST_PRINTF("%s:%u: Failure\n", __FILE__, __LINE__);                    \
+      UTEST_PRINTF("  Expected : (");                                          \
+      UTEST_PRINTF(#x ") " #cond " (" #y);                                     \
+      UTEST_PRINTF(")\n");                                                     \
       UTEST_PRINTF("    Actual : ");                                           \
+      utest_type_printer(xEval);                                               \
+      UTEST_PRINTF(" vs ");                                                    \
       utest_type_printer(yEval);                                               \
       UTEST_PRINTF("\n");                                                      \
       *utest_result = 1;                                                       \
@@ -684,12 +687,14 @@ utest_type_printer(long long unsigned int i) {
                     UTEST_AUTO(x) xEval = (x);                                 \
     UTEST_AUTO(y) yEval = (y);                                                 \
     if (!((xEval)cond(yEval))) {                                               \
-      _Pragma("clang diagnostic pop") UTEST_PRINTF(                            \
-          "%s:%u: Failure (Expected " #cond " Actual)\n", __FILE__, __LINE__); \
-      UTEST_PRINTF("  Expected : ");                                           \
-      utest_type_printer(xEval);                                               \
-      UTEST_PRINTF("\n");                                                      \
+      _Pragma("clang diagnostic pop")                                          \
+          UTEST_PRINTF("%s:%u: Failure\n", __FILE__, __LINE__);                \
+      UTEST_PRINTF("  Expected : (");                                          \
+      UTEST_PRINTF(#x ") " #cond " (" #y);                                     \
+      UTEST_PRINTF(")\n");                                                     \
       UTEST_PRINTF("    Actual : ");                                           \
+      utest_type_printer(xEval);                                               \
+      UTEST_PRINTF(" vs ");                                                    \
       utest_type_printer(yEval);                                               \
       UTEST_PRINTF("\n");                                                      \
       *utest_result = 1;                                                       \
@@ -704,12 +709,13 @@ utest_type_printer(long long unsigned int i) {
     UTEST_AUTO(x) xEval = (x);                                                 \
     UTEST_AUTO(y) yEval = (y);                                                 \
     if (!((xEval)cond(yEval))) {                                               \
-      UTEST_PRINTF("%s:%u: Failure (Expected " #cond " Actual)\n", __FILE__,   \
-                   __LINE__);                                                  \
-      UTEST_PRINTF("  Expected : ");                                           \
-      utest_type_printer(xEval);                                               \
-      UTEST_PRINTF("\n");                                                      \
+      UTEST_PRINTF("%s:%u: Failure\n", __FILE__, __LINE__);                    \
+      UTEST_PRINTF("  Expected : (");                                          \
+      UTEST_PRINTF(#x ") " #cond " (" #y);                                     \
+      UTEST_PRINTF(")\n");                                                     \
       UTEST_PRINTF("    Actual : ");                                           \
+      utest_type_printer(xEval);                                               \
+      UTEST_PRINTF(" vs ");                                                    \
       utest_type_printer(yEval);                                               \
       UTEST_PRINTF("\n");                                                      \
       *utest_result = 1;                                                       \


### PR DESCRIPTION
Fixes #96.

This prints out like:

```
[==========] Running 1 test cases.
[ RUN      ] c.UShort
/Users/neil.henning/Home/utest.h/test/test.c:198: Failure (Expected != Actual)
  Expected : 1
    Actual : 1
[  FAILED  ] c.UShort (727ns)
[==========] 1 test cases ran.
[  PASSED  ] 0 tests.
[  FAILED  ] 1 tests, listed below:
[  FAILED  ] c.UShort
```

Not sure if this is actually good enough, but I'm struggling to come up with a nicer way.