### PR TITLE
Fixed a compilation error on mingw32.

### DIFF
--- a/utest.h
+++ b/utest.h
@@ -180,7 +180,12 @@ UTEST_C_FUNC __declspec(dllimport) int __stdcall QueryPerformanceFrequency(
 #define UTEST_PRId64 "I64d"
 #define UTEST_PRIu64 "I64u"
 #else
+
+#if defined(__cplusplus) && (__cplusplus >= 201103L)
+#include <cinttypes>
+#else
 #include <inttypes.h>
+#endif
 
 #define UTEST_PRId64 PRId64
 #define UTEST_PRIu64 PRIu64


### PR DESCRIPTION
I didn't see mingw32 support in the description, but this small update removes the compilation error on mingw32.  The fact is that <inttypes.h> is deprecated in c++11 and we have to use <cinttypes>. I want to note that the tests on mingw32 still do not work.