### PR TITLE
Fix conflicting types for QueryPerformanceCounter.

### DIFF
--- a/utest.h
+++ b/utest.h
@@ -135,6 +135,9 @@ typedef uint32_t utest_uint32_t;
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #endif
 
+#if defined(_WINDOWS_) || defined(_WINDOWS_H)
+typedef LARGE_INTEGER utest_large_integer;
+#else
 // use old QueryPerformanceCounter definitions (not sure is this needed in some
 // edge cases or not) on Win7 with VS2015 these extern declaration cause "second
 // C linkage of overloaded function not allowed" error
@@ -157,6 +160,7 @@ UTEST_C_FUNC __declspec(dllimport) int __stdcall QueryPerformanceFrequency(
 
 #if defined(__MINGW64__) || defined(__MINGW32__)
 #pragma GCC diagnostic pop
+#endif
 #endif
 
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) ||    \


### PR DESCRIPTION
I tried compiling with the latest version of utest on Mingw-w64 gcc version 12.2.0 (Rev10, Built by MSYS2 project)

and I'm getting this error:

```C
utest.h: error: conflicting types for 'QueryPerformanceCounter'; have 'int(utest_large_integer *)'
      | UTEST_C_FUNC __declspec(dllimport) int __stdcall QueryPerformanceCounter(

note: previous declaration of 'QueryPerformanceCounter' with type 'WINBOOL(LARGE_INTEGER *)' {aka 'int(LARGE_INTEGER *)'}
      |   WINBASEAPI WINBOOL WINAPI QueryPerformanceCounter (LARGE_INTEGER *lpPerformanceCount);
```

Short of a better solution, restoring this if guard fixes it (that code was removed from the PR that added mingw support, aka #115).