### PR TITLE
scan-build fixes.

### DIFF
--- a/utest.h
+++ b/utest.h
@@ -1112,8 +1112,10 @@ utest_type_printer(long long unsigned int i) {
       utest_state.tests[index].func = &utest_##SET##_##NAME;                   \
       utest_state.tests[index].name = name;                                    \
       utest_state.tests[index].index = 0;                                      \
+      UTEST_SNPRINTF(name, name_size, "%s", name_part);                        \
+    } else if (name) {                                                         \
+      free(name);                                                              \
     }                                                                          \
-    UTEST_SNPRINTF(name, name_size, "%s", name_part);                          \
   }                                                                            \
   void utest_run_##SET##_##NAME(int *utest_result)
 
@@ -1163,9 +1165,13 @@ utest_type_printer(long long unsigned int i) {
         utest_realloc(UTEST_PTR_CAST(void *, utest_state.tests),               \
                       sizeof(struct utest_test_state_s) *                      \
                           utest_state.tests_length));                          \
-    utest_state.tests[index].func = &utest_f_##FIXTURE##_##NAME;               \
-    utest_state.tests[index].name = name;                                      \
-    UTEST_SNPRINTF(name, name_size, "%s", name_part);                          \
+    if (utest_state.tests) {                                                   \
+      utest_state.tests[index].func = &utest_f_##FIXTURE##_##NAME;             \
+      utest_state.tests[index].name = name;                                    \
+      UTEST_SNPRINTF(name, name_size, "%s", name_part);                        \
+    } else if (name) {                                                         \
+      free(name);                                                              \
+    }                                                                          \
   }                                                                            \
   UTEST_FIXTURE_SURPRESS_WARNINGS_END                                          \
   void utest_run_##FIXTURE##_##NAME(int *utest_result,                         \
@@ -1206,11 +1212,15 @@ utest_type_printer(long long unsigned int i) {
           utest_realloc(UTEST_PTR_CAST(void *, utest_state.tests),             \
                         sizeof(struct utest_test_state_s) *                    \
                             utest_state.tests_length));                        \
-      utest_state.tests[index].func = &utest_i_##FIXTURE##_##NAME##_##INDEX;   \
-      utest_state.tests[index].index = i;                                      \
-      utest_state.tests[index].name = name;                                    \
-      iUp = UTEST_CAST(utest_uint64_t, i);                                     \
-      UTEST_SNPRINTF(name, name_size, "%s/%" UTEST_PRIu64, name_part, iUp);    \
+      if (utest_state.tests) {                                                 \
+        utest_state.tests[index].func = &utest_i_##FIXTURE##_##NAME##_##INDEX; \
+        utest_state.tests[index].index = i;                                    \
+        utest_state.tests[index].name = name;                                  \
+        iUp = UTEST_CAST(utest_uint64_t, i);                                   \
+        UTEST_SNPRINTF(name, name_size, "%s/%" UTEST_PRIu64, name_part, iUp);  \
+      } else if (name) {                                                       \
+        free(name);                                                            \
+      }                                                                        \
     }                                                                          \
   }                                                                            \
   void utest_run_##FIXTURE##_##NAME##_##INDEX(int *utest_result,               \


### PR DESCRIPTION
When running `scan-build` (i.e. wrapping clang's static code analyser), it'd flag a few possible memory leaks.

This PR makes things a little "safer" as far as clang is concerned (as well as a bit more consistent with each other), despite how unlikely the error state is to occur.