### PR TITLE
Refactor tests

### DIFF
--- a/utest.h
+++ b/utest.h
@@ -810,7 +810,7 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
 #define EXPECT_TRUE(x) UTEST_TRUE(x, 0)
 #define ASSERT_TRUE(x) UTEST_TRUE(x, 1)
 
-#define EXPECT_FALSE(x)                                                        \
+#define UTEST_FALSE(x, is_assert)                                              \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \
     const int xEval = !!(x);                                                   \
     if (xEval) {                                                               \
@@ -818,10 +818,14 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
       UTEST_PRINTF("  Expected : false\n");                                    \
       UTEST_PRINTF("    Actual : %s\n", (xEval) ? "true" : "false");           \
       *utest_result = UTEST_TEST_FAILURE;                                      \
+      if (is_assert) return;                                                   \
     }                                                                          \
   }                                                                            \
   while (0)                                                                    \
   UTEST_SURPRESS_WARNING_END
+
+#define EXPECT_FALSE(x) UTEST_FALSE(x, 0)
+#define ASSERT_FALSE(x) UTEST_FALSE(x, 1)
 
 #define EXPECT_STREQ(x, y)                                                     \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \
@@ -959,20 +963,6 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
   while (0)                                                                    \
   UTEST_SURPRESS_WARNING_END
 #endif
-
-#define ASSERT_FALSE(x)                                                        \
-  UTEST_SURPRESS_WARNING_BEGIN do {                                            \
-    const int xEval = !!(x);                                                   \
-    if (xEval) {                                                               \
-      UTEST_PRINTF("%s:%i: Failure\n", __FILE__, __LINE__);                    \
-      UTEST_PRINTF("  Expected : false\n");                                    \
-      UTEST_PRINTF("    Actual : %s\n", (xEval) ? "true" : "false");           \
-      *utest_result = UTEST_TEST_FAILURE;                                      \
-      return;                                                                  \
-    }                                                                          \
-  }                                                                            \
-  while (0)                                                                    \
-  UTEST_SURPRESS_WARNING_END
 
 #define ASSERT_STREQ(x, y)                                                     \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \

--- a/utest.h
+++ b/utest.h
@@ -885,7 +885,7 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
 #define EXPECT_STRNEQ(x, y, n) UTEST_STRNEQ(x, y, n, 0)
 #define ASSERT_STRNEQ(x, y, n) UTEST_STRNEQ(x, y, n, 1)
 
-#define EXPECT_STRNNE(x, y, n)                                                 \
+#define UTEST_STRNNE(x, y, n, is_assert)                                       \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \
     const char *xEval = (x);                                                   \
     const char *yEval = (y);                                                   \
@@ -896,10 +896,14 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
       UTEST_PRINTF("  Expected : \"%.*s\"\n", UTEST_CAST(int, nEval), xEval);  \
       UTEST_PRINTF("    Actual : \"%.*s\"\n", UTEST_CAST(int, nEval), yEval);  \
       *utest_result = UTEST_TEST_FAILURE;                                      \
+      if (is_assert) return;                                                   \
     }                                                                          \
   }                                                                            \
   while (0)                                                                    \
   UTEST_SURPRESS_WARNING_END
+
+#define EXPECT_STRNNE(x, y, n) UTEST_STRNNE(x, y, n, 0)
+#define ASSERT_STRNNE(x, y, n) UTEST_STRNNE(x, y, n, 1)
 
 #define EXPECT_NEAR(x, y, epsilon)                                             \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \
@@ -975,23 +979,6 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
   while (0)                                                                    \
   UTEST_SURPRESS_WARNING_END
 #endif
-
-#define ASSERT_STRNNE(x, y, n)                                                 \
-  UTEST_SURPRESS_WARNING_BEGIN do {                                            \
-    const char *xEval = (x);                                                   \
-    const char *yEval = (y);                                                   \
-    const size_t nEval = UTEST_CAST(size_t, n);                                \
-    if (UTEST_NULL == xEval || UTEST_NULL == yEval ||                          \
-        0 == UTEST_STRNCMP(xEval, yEval, nEval)) {                             \
-      UTEST_PRINTF("%s:%i: Failure\n", __FILE__, __LINE__);                    \
-      UTEST_PRINTF("  Expected : \"%.*s\"\n", UTEST_CAST(int, nEval), xEval);  \
-      UTEST_PRINTF("    Actual : \"%.*s\"\n", UTEST_CAST(int, nEval), yEval);  \
-      *utest_result = UTEST_TEST_FAILURE;                                      \
-      return;                                                                  \
-    }                                                                          \
-  }                                                                            \
-  while (0)                                                                    \
-  UTEST_SURPRESS_WARNING_END
 
 #define ASSERT_NEAR(x, y, epsilon)                                             \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \

--- a/utest.h
+++ b/utest.h
@@ -827,7 +827,7 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
 #define EXPECT_FALSE(x) UTEST_FALSE(x, 0)
 #define ASSERT_FALSE(x) UTEST_FALSE(x, 1)
 
-#define EXPECT_STREQ(x, y)                                                     \
+#define UTEST_STREQ(x, y, is_assert)                                           \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \
     const char *xEval = (x);                                                   \
     const char *yEval = (y);                                                   \
@@ -837,10 +837,14 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
       UTEST_PRINTF("  Expected : \"%s\"\n", xEval);                            \
       UTEST_PRINTF("    Actual : \"%s\"\n", yEval);                            \
       *utest_result = UTEST_TEST_FAILURE;                                      \
+      if (is_assert) return;                                                   \
     }                                                                          \
   }                                                                            \
   while (0)                                                                    \
   UTEST_SURPRESS_WARNING_END
+
+#define EXPECT_STREQ(x, y) UTEST_STREQ(x, y, 0)
+#define ASSERT_STREQ(x, y) UTEST_STREQ(x, y, 1)
 
 #define EXPECT_STRNE(x, y)                                                     \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \
@@ -963,22 +967,6 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
   while (0)                                                                    \
   UTEST_SURPRESS_WARNING_END
 #endif
-
-#define ASSERT_STREQ(x, y)                                                     \
-  UTEST_SURPRESS_WARNING_BEGIN do {                                            \
-    const char *xEval = (x);                                                   \
-    const char *yEval = (y);                                                   \
-    if (UTEST_NULL == xEval || UTEST_NULL == yEval ||                          \
-        0 != strcmp(xEval, yEval)) {                                           \
-      UTEST_PRINTF("%s:%i: Failure\n", __FILE__, __LINE__);                    \
-      UTEST_PRINTF("  Expected : \"%s\"\n", xEval);                            \
-      UTEST_PRINTF("    Actual : \"%s\"\n", yEval);                            \
-      *utest_result = UTEST_TEST_FAILURE;                                      \
-      return;                                                                  \
-    }                                                                          \
-  }                                                                            \
-  while (0)                                                                    \
-  UTEST_SURPRESS_WARNING_END
 
 #define ASSERT_STRNE(x, y)                                                     \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \

--- a/utest.h
+++ b/utest.h
@@ -865,7 +865,7 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
 #define EXPECT_STRNE(x, y) UTEST_STRNE(x, y, 0)
 #define ASSERT_STRNE(x, y) UTEST_STRNE(x, y, 1)
 
-#define EXPECT_STRNEQ(x, y, n)                                                 \
+#define UTEST_STRNEQ(x, y, n, is_assert)                                       \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \
     const char *xEval = (x);                                                   \
     const char *yEval = (y);                                                   \
@@ -876,10 +876,14 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
       UTEST_PRINTF("  Expected : \"%.*s\"\n", UTEST_CAST(int, nEval), xEval);  \
       UTEST_PRINTF("    Actual : \"%.*s\"\n", UTEST_CAST(int, nEval), yEval);  \
       *utest_result = UTEST_TEST_FAILURE;                                      \
+      if (is_assert) return;                                                   \
     }                                                                          \
   }                                                                            \
   while (0)                                                                    \
   UTEST_SURPRESS_WARNING_END
+
+#define EXPECT_STRNEQ(x, y, n) UTEST_STRNEQ(x, y, n, 0)
+#define ASSERT_STRNEQ(x, y, n) UTEST_STRNEQ(x, y, n, 1)
 
 #define EXPECT_STRNNE(x, y, n)                                                 \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \
@@ -971,23 +975,6 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
   while (0)                                                                    \
   UTEST_SURPRESS_WARNING_END
 #endif
-
-#define ASSERT_STRNEQ(x, y, n)                                                 \
-  UTEST_SURPRESS_WARNING_BEGIN do {                                            \
-    const char *xEval = (x);                                                   \
-    const char *yEval = (y);                                                   \
-    const size_t nEval = UTEST_CAST(size_t, n);                                \
-    if (UTEST_NULL == xEval || UTEST_NULL == yEval ||                          \
-        0 != UTEST_STRNCMP(xEval, yEval, nEval)) {                             \
-      UTEST_PRINTF("%s:%i: Failure\n", __FILE__, __LINE__);                    \
-      UTEST_PRINTF("  Expected : \"%.*s\"\n", UTEST_CAST(int, nEval), xEval);  \
-      UTEST_PRINTF("    Actual : \"%.*s\"\n", UTEST_CAST(int, nEval), yEval);  \
-      *utest_result = UTEST_TEST_FAILURE;                                      \
-      return;                                                                  \
-    }                                                                          \
-  }                                                                            \
-  while (0)                                                                    \
-  UTEST_SURPRESS_WARNING_END
 
 #define ASSERT_STRNNE(x, y, n)                                                 \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \

--- a/utest.h
+++ b/utest.h
@@ -924,7 +924,7 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
 #define ASSERT_NEAR(x, y, epsilon) UTEST_NEAR(x, y, epsilon, 1)
 
 #if defined(UTEST_HAS_EXCEPTIONS)
-#define EXPECT_EXCEPTION(x, exception_type)                                    \
+#define UTEST_EXCEPTION(x, exception_type, is_assert)                          \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \
     int exception_caught = 0;                                                  \
     try {                                                                      \
@@ -941,10 +941,16 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
                                             ? "Unexpected exception"           \
                                             : "No exception");                 \
       *utest_result = UTEST_TEST_FAILURE;                                      \
+      if (is_assert) return;                                                   \
     }                                                                          \
   }                                                                            \
   while (0)                                                                    \
   UTEST_SURPRESS_WARNING_END
+
+#define EXPECT_EXCEPTION(x, exception_type)                                    \
+  UTEST_EXCEPTION(x, exception_type, 0)
+#define ASSERT_EXCEPTION(x, exception_type)                                    \
+  UTEST_EXCEPTION(x, exception_type, 1)
 
 #define EXPECT_EXCEPTION_WITH_MESSAGE(x, exception_type, exception_message)    \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \
@@ -985,29 +991,6 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
 #endif
 
 #if defined(UTEST_HAS_EXCEPTIONS)
-#define ASSERT_EXCEPTION(x, exception_type)                                    \
-  UTEST_SURPRESS_WARNING_BEGIN do {                                            \
-    int exception_caught = 0;                                                  \
-    try {                                                                      \
-      x;                                                                       \
-    } catch (const exception_type &) {                                         \
-      exception_caught = 1;                                                    \
-    } catch (...) {                                                            \
-      exception_caught = 2;                                                    \
-    }                                                                          \
-    if (1 != exception_caught) {                                               \
-      UTEST_PRINTF("%s:%i: Failure\n", __FILE__, __LINE__);                    \
-      UTEST_PRINTF("  Expected : %s exception\n", #exception_type);            \
-      UTEST_PRINTF("    Actual : %s\n", (2 == exception_caught)                \
-                                            ? "Unexpected exception"           \
-                                            : "No exception");                 \
-      *utest_result = UTEST_TEST_FAILURE;                                      \
-      return;                                                                  \
-    }                                                                          \
-  }                                                                            \
-  while (0)                                                                    \
-  UTEST_SURPRESS_WARNING_END
-
 #define ASSERT_EXCEPTION_WITH_MESSAGE(x, exception_type, exception_message)    \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \
     int exception_caught = 0;                                                  \

--- a/utest.h
+++ b/utest.h
@@ -846,7 +846,7 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
 #define EXPECT_STREQ(x, y) UTEST_STREQ(x, y, 0)
 #define ASSERT_STREQ(x, y) UTEST_STREQ(x, y, 1)
 
-#define EXPECT_STRNE(x, y)                                                     \
+#define UTEST_STRNE(x, y, is_assert)                                           \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \
     const char *xEval = (x);                                                   \
     const char *yEval = (y);                                                   \
@@ -856,10 +856,14 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
       UTEST_PRINTF("  Expected : \"%s\"\n", xEval);                            \
       UTEST_PRINTF("    Actual : \"%s\"\n", yEval);                            \
       *utest_result = UTEST_TEST_FAILURE;                                      \
+      if (is_assert) return;                                                   \
     }                                                                          \
   }                                                                            \
   while (0)                                                                    \
   UTEST_SURPRESS_WARNING_END
+
+#define EXPECT_STRNE(x, y) UTEST_STRNE(x, y, 0)
+#define ASSERT_STRNE(x, y) UTEST_STRNE(x, y, 1)
 
 #define EXPECT_STRNEQ(x, y, n)                                                 \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \
@@ -967,22 +971,6 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
   while (0)                                                                    \
   UTEST_SURPRESS_WARNING_END
 #endif
-
-#define ASSERT_STRNE(x, y)                                                     \
-  UTEST_SURPRESS_WARNING_BEGIN do {                                            \
-    const char *xEval = (x);                                                   \
-    const char *yEval = (y);                                                   \
-    if (UTEST_NULL == xEval || UTEST_NULL == yEval ||                          \
-        0 == strcmp(xEval, yEval)) {                                           \
-      UTEST_PRINTF("%s:%i: Failure\n", __FILE__, __LINE__);                    \
-      UTEST_PRINTF("  Expected : \"%s\"\n", xEval);                            \
-      UTEST_PRINTF("    Actual : \"%s\"\n", yEval);                            \
-      *utest_result = UTEST_TEST_FAILURE;                                      \
-      return;                                                                  \
-    }                                                                          \
-  }                                                                            \
-  while (0)                                                                    \
-  UTEST_SURPRESS_WARNING_END
 
 #define ASSERT_STRNEQ(x, y, n)                                                 \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \

--- a/utest.h
+++ b/utest.h
@@ -952,7 +952,7 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
 #define ASSERT_EXCEPTION(x, exception_type)                                    \
   UTEST_EXCEPTION(x, exception_type, 1)
 
-#define EXPECT_EXCEPTION_WITH_MESSAGE(x, exception_type, exception_message)    \
+#define UTEST_EXCEPTION_WITH_MESSAGE(x, exception_type, exception_message, is_assert) \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \
     int exception_caught = 0;                                                  \
     char *message_caught = UTEST_NULL;                                         \
@@ -977,6 +977,7 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
                                             ? "Unexpected exception"           \
                                             : "No exception");                 \
       *utest_result = UTEST_TEST_FAILURE;                                      \
+      if (is_assert) return;                                                   \
     } else if (UTEST_NULL != message_caught) {                                 \
       UTEST_PRINTF("%s:%i: Failure\n", __FILE__, __LINE__);                    \
       UTEST_PRINTF("  Expected : %s exception with message %s\n",              \
@@ -984,51 +985,16 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
       UTEST_PRINTF("    Actual message : %s\n", message_caught);               \
       *utest_result = UTEST_TEST_FAILURE;                                      \
       free(message_caught);                                                    \
+      if (is_assert) return;                                                   \
     }                                                                          \
   }                                                                            \
   while (0)                                                                    \
   UTEST_SURPRESS_WARNING_END
-#endif
 
-#if defined(UTEST_HAS_EXCEPTIONS)
+#define EXPECT_EXCEPTION_WITH_MESSAGE(x, exception_type, exception_message)    \
+  UTEST_EXCEPTION_WITH_MESSAGE(x, exception_type, exception_message, 0)
 #define ASSERT_EXCEPTION_WITH_MESSAGE(x, exception_type, exception_message)    \
-  UTEST_SURPRESS_WARNING_BEGIN do {                                            \
-    int exception_caught = 0;                                                  \
-    char *message_caught = UTEST_NULL;                                         \
-    try {                                                                      \
-      x;                                                                       \
-    } catch (const exception_type &e) {                                        \
-      const char *const what = e.what();                                       \
-      exception_caught = 1;                                                    \
-      if (0 !=                                                                 \
-          UTEST_STRNCMP(what, exception_message, strlen(exception_message))) { \
-        const size_t message_size = strlen(what) + 1;                          \
-        message_caught = UTEST_PTR_CAST(char *, malloc(message_size));         \
-        UTEST_STRNCPY(message_caught, what, message_size);                     \
-      }                                                                        \
-    } catch (...) {                                                            \
-      exception_caught = 2;                                                    \
-    }                                                                          \
-    if (1 != exception_caught) {                                               \
-      UTEST_PRINTF("%s:%i: Failure\n", __FILE__, __LINE__);                    \
-      UTEST_PRINTF("  Expected : %s exception\n", #exception_type);            \
-      UTEST_PRINTF("    Actual : %s\n", (2 == exception_caught)                \
-                                            ? "Unexpected exception"           \
-                                            : "No exception");                 \
-      *utest_result = UTEST_TEST_FAILURE;                                      \
-      return;                                                                  \
-    } else if (UTEST_NULL != message_caught) {                                 \
-      UTEST_PRINTF("%s:%i: Failure\n", __FILE__, __LINE__);                    \
-      UTEST_PRINTF("  Expected : %s exception with message %s\n",              \
-                   #exception_type, exception_message);                        \
-      UTEST_PRINTF("    Actual message : %s\n", message_caught);               \
-      *utest_result = UTEST_TEST_FAILURE;                                      \
-      free(message_caught);                                                    \
-      return;                                                                  \
-    }                                                                          \
-  }                                                                            \
-  while (0)                                                                    \
-  UTEST_SURPRESS_WARNING_END
+  UTEST_EXCEPTION_WITH_MESSAGE(x, exception_type, exception_message, 1)
 #endif
 
 #define UTEST(SET, NAME)                                                       \

--- a/utest.h
+++ b/utest.h
@@ -905,7 +905,7 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
 #define EXPECT_STRNNE(x, y, n) UTEST_STRNNE(x, y, n, 0)
 #define ASSERT_STRNNE(x, y, n) UTEST_STRNNE(x, y, n, 1)
 
-#define EXPECT_NEAR(x, y, epsilon)                                             \
+#define UTEST_NEAR(x, y, epsilon, is_assert)                                   \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \
     const double diff =                                                        \
         utest_fabs(UTEST_CAST(double, x) - UTEST_CAST(double, y));             \
@@ -914,10 +914,14 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
       UTEST_PRINTF("  Expected : %f\n", UTEST_CAST(double, x));                \
       UTEST_PRINTF("    Actual : %f\n", UTEST_CAST(double, y));                \
       *utest_result = UTEST_TEST_FAILURE;                                      \
+      if (is_assert) return;                                                   \
     }                                                                          \
   }                                                                            \
   while (0)                                                                    \
   UTEST_SURPRESS_WARNING_END
+
+#define EXPECT_NEAR(x, y, epsilon) UTEST_NEAR(x, y, epsilon, 0)
+#define ASSERT_NEAR(x, y, epsilon) UTEST_NEAR(x, y, epsilon, 1)
 
 #if defined(UTEST_HAS_EXCEPTIONS)
 #define EXPECT_EXCEPTION(x, exception_type)                                    \
@@ -979,21 +983,6 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
   while (0)                                                                    \
   UTEST_SURPRESS_WARNING_END
 #endif
-
-#define ASSERT_NEAR(x, y, epsilon)                                             \
-  UTEST_SURPRESS_WARNING_BEGIN do {                                            \
-    const double diff =                                                        \
-        utest_fabs(UTEST_CAST(double, x) - UTEST_CAST(double, y));             \
-    if (diff > UTEST_CAST(double, epsilon) || utest_isnan(diff)) {             \
-      UTEST_PRINTF("%s:%i: Failure\n", __FILE__, __LINE__);                    \
-      UTEST_PRINTF("  Expected : %f\n", UTEST_CAST(double, x));                \
-      UTEST_PRINTF("    Actual : %f\n", UTEST_CAST(double, y));                \
-      *utest_result = UTEST_TEST_FAILURE;                                      \
-      return;                                                                  \
-    }                                                                          \
-  }                                                                            \
-  while (0)                                                                    \
-  UTEST_SURPRESS_WARNING_END
 
 #if defined(UTEST_HAS_EXCEPTIONS)
 #define ASSERT_EXCEPTION(x, exception_type)                                    \

--- a/utest.h
+++ b/utest.h
@@ -793,7 +793,7 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
 #define EXPECT_GE(x, y) UTEST_COND(x, y, >=, 0)
 #define ASSERT_GE(x, y) UTEST_COND(x, y, >=, 1)
 
-#define EXPECT_TRUE(x)                                                         \
+#define UTEST_TRUE(x, is_assert)                                               \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \
     const int xEval = !!(x);                                                   \
     if (!(xEval)) {                                                            \
@@ -801,10 +801,14 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
       UTEST_PRINTF("  Expected : true\n");                                     \
       UTEST_PRINTF("    Actual : %s\n", (xEval) ? "true" : "false");           \
       *utest_result = UTEST_TEST_FAILURE;                                      \
+      if (is_assert) return;                                                   \
     }                                                                          \
   }                                                                            \
   while (0)                                                                    \
   UTEST_SURPRESS_WARNING_END
+
+#define EXPECT_TRUE(x) UTEST_TRUE(x, 0)
+#define ASSERT_TRUE(x) UTEST_TRUE(x, 1)
 
 #define EXPECT_FALSE(x)                                                        \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \
@@ -955,20 +959,6 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
   while (0)                                                                    \
   UTEST_SURPRESS_WARNING_END
 #endif
-
-#define ASSERT_TRUE(x)                                                         \
-  UTEST_SURPRESS_WARNING_BEGIN do {                                            \
-    const int xEval = !!(x);                                                   \
-    if (!(xEval)) {                                                            \
-      UTEST_PRINTF("%s:%i: Failure\n", __FILE__, __LINE__);                    \
-      UTEST_PRINTF("  Expected : true\n");                                     \
-      UTEST_PRINTF("    Actual : %s\n", (xEval) ? "true" : "false");           \
-      *utest_result = UTEST_TEST_FAILURE;                                      \
-      return;                                                                  \
-    }                                                                          \
-  }                                                                            \
-  while (0)                                                                    \
-  UTEST_SURPRESS_WARNING_END
 
 #define ASSERT_FALSE(x)                                                        \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \


### PR DESCRIPTION
When I recently added `EXPECT_EXCEPTION_WITH_MESSAGE` and `ASSERT_EXCEPTION_WITH_MESSAGE`, I noticed that tests need to be defined twice, once for "expect" and once for "assert". This PR is a refactor for using the same macros for tests and then defining "expect" and "assert" accordingly. Reduce the `utest.h` length from 1715 lines to 1529 lines (~11% less).  
I made a commit for each test to make it easier to review.