### PR TITLE
Remove UTEST_ATTRIBUTE, __attribute works everywhere.

### DIFF
--- a/utest.h
+++ b/utest.h
@@ -127,12 +127,6 @@ typedef uint32_t utest_uint32_t;
 #define UTEST_TEST_FAILURE (1)
 #define UTEST_TEST_SKIPPED (2)
 
-#if defined(__TINYC__)
-#define UTEST_ATTRIBUTE(a) __attribute((a))
-#else
-#define UTEST_ATTRIBUTE(a) __attribute__((a))
-#endif
-
 #if defined(_MSC_VER) || defined(__MINGW64__) || defined(__MINGW32__)
 
 #if defined(__MINGW64__) || defined(__MINGW32__)
@@ -280,7 +274,7 @@ UTEST_C_FUNC __declspec(dllimport) int __stdcall QueryPerformanceFrequency(
 #define UTEST_INLINE inline
 
 #define UTEST_INITIALIZER(f)                                                   \
-  static void f(void) UTEST_ATTRIBUTE(constructor);                            \
+  static void f(void) __attribute((constructor));                              \
   static void f(void)
 #endif
 
@@ -382,9 +376,9 @@ UTEST_EXTERN struct utest_state_s utest_state;
 #if defined(_MSC_VER)
 #define UTEST_WEAK __forceinline
 #elif defined(__MINGW32__) || defined(__MINGW64__)
-#define UTEST_WEAK static UTEST_ATTRIBUTE(used)
+#define UTEST_WEAK static __attribute((used))
 #elif defined(__clang__) || defined(__GNUC__) || defined(__TINYC__)
-#define UTEST_WEAK UTEST_ATTRIBUTE(weak)
+#define UTEST_WEAK __attribute((weak))
 #else
 #error Non clang, non gcc, non MSVC, non tcc compiler found!
 #endif
@@ -392,7 +386,7 @@ UTEST_EXTERN struct utest_state_s utest_state;
 #if defined(_MSC_VER)
 #define UTEST_UNUSED
 #else
-#define UTEST_UNUSED UTEST_ATTRIBUTE(unused)
+#define UTEST_UNUSED __attribute((unused))
 #endif
 
 #ifdef __clang__
@@ -430,7 +424,7 @@ UTEST_EXTERN struct utest_state_s utest_state;
 #define UTEST_OVERLOADABLE
 #elif defined(__clang__)
 /* otherwise, if we are using clang with c - use the overloadable attribute */
-#define UTEST_OVERLOADABLE UTEST_ATTRIBUTE(overloadable)
+#define UTEST_OVERLOADABLE __attribute((overloadable))
 #endif
 
 #if defined(__cplusplus) && (__cplusplus >= 201103L)


### PR DESCRIPTION
I added UTEST_ATTRIBUTE for tcc compatibiliy some time ago, it is unnecessary because `__attribute` works everywhere.