### PR TITLE
Add *_PRED_* tests: A predicate test that uses a provided function for comparing values

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -259,3 +259,14 @@ UTEST(c, Near) {
 }
 
 UTEST(c, Todo) { UTEST_SKIP("Not yet implemented!"); }
+
+int test_func_int(int a, int b)
+{
+	return a<b; 
+}
+
+UTEST(c, Predicate) {
+  EXPECT_PRED(1, 2, test_func_int);
+  ASSERT_PRED(1, 2, test_func_int);
+}
+

--- a/test/test.c
+++ b/test/test.c
@@ -260,7 +260,7 @@ UTEST(c, Near) {
 
 UTEST(c, Todo) { UTEST_SKIP("Not yet implemented!"); }
 
-int test_func_int(int a, int b)
+static int test_func_int(int a, int b)
 {
 	return a<b; 
 }

--- a/test/test11.cpp
+++ b/test/test11.cpp
@@ -329,3 +329,9 @@ UTEST(cpp11, EnumClass) {
 #pragma clang diagnostic pop
 #endif
 #endif
+
+UTEST(cpp, Predicate) {
+  EXPECT_PRED(1, 2, [](int a, int b){return a<b;});
+  EXPECT_PRED(1.0f, 2.0f, [](float a, float b){float res = a-b; return res > -1.00001 && res < -0.99999 ;});
+  ASSERT_PRED(1, 2, [](int a, int b){return a<b;});
+}

--- a/test/test11.cpp
+++ b/test/test11.cpp
@@ -332,6 +332,6 @@ UTEST(cpp11, EnumClass) {
 
 UTEST(cpp, Predicate) {
   EXPECT_PRED(1, 2, [](int a, int b){return a<b;});
-  EXPECT_PRED(1.0f, 2.0f, [](float a, float b){float res = a-b; return res > -1.00001 && res < -0.99999 ;});
+  EXPECT_PRED(1.0f, 2.0f, [](float a, float b){float res = a-b; return res > -1.00001f && res < -0.99999f;});
   ASSERT_PRED(1, 2, [](int a, int b){return a<b;});
 }

--- a/utest.h
+++ b/utest.h
@@ -1104,6 +1104,35 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
   UTEST_EXCEPTION_WITH_MESSAGE(x, exception_type, exception_message, msg, 1)
 #endif
 
+#define UTEST_PRED(x, y, pred , msg, is_assert)                                \
+  UTEST_SURPRESS_WARNING_BEGIN do {                                            \
+    UTEST_AUTO(x) xEval = (x);                                                 \
+    UTEST_AUTO(y) yEval = (y);                                                 \
+    if (!pred(xEval, yEval)) {                                                 \
+      UTEST_PRINTF("%s:%i: Failure\n", __FILE__, __LINE__);                    \
+      UTEST_PRINTF("    Actual : ");                                           \
+      utest_type_printer(xEval);                                               \
+      UTEST_PRINTF(" vs ");                                                    \
+      utest_type_printer(yEval);                                               \
+      UTEST_PRINTF("\n");                                                      \
+      if (strlen(msg) > 0) {                                                   \
+        UTEST_PRINTF("   Message : %s\n", msg);                                \
+      }                                                                        \
+      *utest_result = UTEST_TEST_FAILURE;                                      \
+      if (is_assert) {                                                         \
+        return;                                                                \
+      }                                                                        \
+    }                                                                          \
+  }                                                                            \
+  while (0)                                                                    \
+  UTEST_SURPRESS_WARNING_END
+
+#define EXPECT_PRED(x, y, pred) UTEST_PRED(x, y, pred, "", 0)
+#define EXPECT_PRED_MSG(x, y, pred, msg) UTEST_PRED(x, y, pred, msg, 0)
+#define ASSERT_PRED(x, y, pred) UTEST_PRED(x, y, pred, "", 1)
+#define ASSERT_PRED_MSG(x, y, pred, msg) UTEST_PRED(x, y, pred, msg, 1)
+
+
 #if defined(__clang__)
 #if __has_warning("-Wunsafe-buffer-usage")
 #define UTEST_SURPRESS_WARNINGS_BEGIN                                          \


### PR DESCRIPTION
Uses a provided function that returns bool (or int in c)  to compare provided test values

This is useful if you want compare some complex values, or for example a float in a range not only near a delta ecc...
See test case for examples