### PR TITLE
Fix memory leak in utest_realloc.

### DIFF
--- a/utest.h
+++ b/utest.h
@@ -321,7 +321,7 @@ static UTEST_INLINE void *utest_realloc(void *const pointer, size_t new_size) {
   void *const new_pointer = realloc(pointer, new_size);
 
   if (UTEST_NULL == new_pointer) {
-    free(new_pointer);
+    free(pointer);
   }
 
   return new_pointer;


### PR DESCRIPTION
It doesn't make sense to free the null pointer here. Furthermore, given that users of this function simply lose track of the pointer in case realloc fails, "utest_realloc" should free the pointer passed to it to avoid leaking memory.