### PR TITLE
Fix logic for handling test case name allocation.

### DIFF
--- a/utest.h
+++ b/utest.h
@@ -1142,13 +1142,19 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
         utest_realloc(UTEST_PTR_CAST(void *, utest_state.tests),               \
                       sizeof(struct utest_test_state_s) *                      \
                           utest_state.tests_length));                          \
-    if (utest_state.tests) {                                                   \
+    if (utest_state.tests && name) {                                           \
       utest_state.tests[index].func = &utest_##SET##_##NAME;                   \
       utest_state.tests[index].name = name;                                    \
       utest_state.tests[index].index = 0;                                      \
       UTEST_SNPRINTF(name, name_size, "%s", name_part);                        \
-    } else if (name) {                                                         \
-      free(name);                                                              \
+    } else {                                                                   \
+      if (utest_state.tests) {                                                 \
+        free(utest_state.tests);                                               \
+        utest_state.tests = NULL;                                              \
+      }                                                                        \
+      if (name) {                                                              \
+        free(name);                                                            \
+      }                                                                        \
     }                                                                          \
   }                                                                            \
   UTEST_SURPRESS_WARNINGS_END                                                  \
@@ -1190,12 +1196,18 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
         utest_realloc(UTEST_PTR_CAST(void *, utest_state.tests),               \
                       sizeof(struct utest_test_state_s) *                      \
                           utest_state.tests_length));                          \
-    if (utest_state.tests) {                                                   \
+    if (utest_state.tests && name) {                                           \
       utest_state.tests[index].func = &utest_f_##FIXTURE##_##NAME;             \
       utest_state.tests[index].name = name;                                    \
       UTEST_SNPRINTF(name, name_size, "%s", name_part);                        \
-    } else if (name) {                                                         \
-      free(name);                                                              \
+    } else {                                                                   \
+      if (utest_state.tests) {                                                 \
+        free(utest_state.tests);                                               \
+        utest_state.tests = NULL;                                              \
+      }                                                                        \
+      if (name) {                                                              \
+        free(name);                                                            \
+      }                                                                        \
     }                                                                          \
   }                                                                            \
   UTEST_SURPRESS_WARNINGS_END                                                  \
@@ -1238,14 +1250,20 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
           utest_realloc(UTEST_PTR_CAST(void *, utest_state.tests),             \
                         sizeof(struct utest_test_state_s) *                    \
                             utest_state.tests_length));                        \
-      if (utest_state.tests) {                                                 \
+      if (utest_state.tests && name) {                                         \
         utest_state.tests[index].func = &utest_i_##FIXTURE##_##NAME##_##INDEX; \
         utest_state.tests[index].index = i;                                    \
         utest_state.tests[index].name = name;                                  \
         iUp = UTEST_CAST(utest_uint64_t, i);                                   \
         UTEST_SNPRINTF(name, name_size, "%s/%" UTEST_PRIu64, name_part, iUp);  \
-      } else if (name) {                                                       \
-        free(name);                                                            \
+      } else {                                                                 \
+        if (utest_state.tests) {                                               \
+          free(utest_state.tests);                                             \
+          utest_state.tests = NULL;                                            \
+        }                                                                      \
+        if (name) {                                                            \
+          free(name);                                                          \
+        }                                                                      \
       }                                                                        \
     }                                                                          \
   }                                                                            \


### PR DESCRIPTION
Setting the test case information and writing into its name should only happen when both allocations succeed; otherwise, it might be necessary to free one or both of the used pointers. utest_state.tests has to be set to NULL to avoid a UAF as well.

---

In case support for `free(NULL);` is a reasonable assumption, the code can be shortened a bit by avoiding the unnecessary conditionals. Please let me know :)

One curiosity that came up while I was looking at this and #147 is: what's the intended behavior in case memory allocation fails while instantiating test cases? I didn't take a deep look, but it seemed to me like some tests would simply be omitted, without warning the user.