### PR TITLE
Remove superfluous semicolon from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ googletest framework:
 In one C or C++ file, you must call the macro UTEST_MAIN:
 
 ```c
-UTEST_MAIN();
+UTEST_MAIN()
 ```
 
 This will call into utest.h, instantiate all the testcases and run the unit test


### PR DESCRIPTION
The semicolon results in a compiler warning when -Wextra-semi is enabled. To be able to allow to use utest.h in projects with strict compiler flags enabled, the semicolon should be removed from the documentation.