### PR TITLE
feat: add boolean eval

### DIFF
--- a/test/test11.cpp
+++ b/test/test11.cpp
@@ -96,6 +96,13 @@ UTEST(cpp11, no_double_eval) {
   ASSERT_EQ(i, 1);
 }
 
+UTEST(cpp11, bool_eval) {
+  bool i = false;
+  ASSERT_EQ(i, false);
+  i = true;
+  ASSERT_EQ(i, true);
+}
+
 struct MyTestF {
   int foo;
 };

--- a/test/test14.cpp
+++ b/test/test14.cpp
@@ -96,6 +96,13 @@ UTEST(cpp14, no_double_eval) {
   ASSERT_EQ(i, 1);
 }
 
+UTEST(cpp14, bool_eval) {
+  bool i = false;
+  ASSERT_EQ(i, false);
+  i = true;
+  ASSERT_EQ(i, true);
+}
+
 struct MyTestF {
   int foo;
 };

--- a/test/test17.cpp
+++ b/test/test17.cpp
@@ -96,6 +96,13 @@ UTEST(cpp17, no_double_eval) {
   ASSERT_EQ(i, 1);
 }
 
+UTEST(cpp17, bool_eval) {
+  bool i = false;
+  ASSERT_EQ(i, false);
+  i = true;
+  ASSERT_EQ(i, true);
+}
+
 struct MyTestF {
   int foo;
 };

--- a/utest.h
+++ b/utest.h
@@ -512,6 +512,10 @@ template <> struct utest_type_deducer<unsigned long long, false> {
   static void _(const unsigned long long i) { UTEST_PRINTF("%llu", i); }
 };
 
+template <> struct utest_type_deducer<bool, false> {
+  static void _(const bool i) { UTEST_PRINTF(i ? "true" : "false"); }
+};
+
 template <typename T> struct utest_type_deducer<const T *, false> {
   static void _(const T *t) {
     UTEST_PRINTF("%p", static_cast<void *>(const_cast<T *>(t)));


### PR DESCRIPTION
just so when you pass a boolean value in C++. this type is not define so this will hit a compiling error if you pass in a boolean type to ASSERT_EQ