### PR TITLE
Fix signed integer overflow.

### DIFF
--- a/utest.h
+++ b/utest.h
@@ -334,7 +334,7 @@ static UTEST_INLINE utest_int64_t utest_ns(void) {
   QueryPerformanceCounter(&counter);
   QueryPerformanceFrequency(&frequency);
   return UTEST_CAST(utest_int64_t,
-                    (UTEST_CAST(utest_uint64_t, counter.QuadPart) * 1000000000ULL) / frequency.QuadPart);
+                    (counter.QuadPart / frequency.QuadPart * 1000000000));
 #elif defined(__linux__) && defined(__STRICT_ANSI__)
   return UTEST_CAST(utest_int64_t, clock()) * 1000000000 / CLOCKS_PER_SEC;
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) ||    \

--- a/utest.h
+++ b/utest.h
@@ -334,7 +334,7 @@ static UTEST_INLINE utest_int64_t utest_ns(void) {
   QueryPerformanceCounter(&counter);
   QueryPerformanceFrequency(&frequency);
   return UTEST_CAST(utest_int64_t,
-                    (counter.QuadPart * 1000000000) / frequency.QuadPart);
+                    (UTEST_CAST(utest_uint64_t, counter.QuadPart) * 1000000000ULL) / frequency.QuadPart);
 #elif defined(__linux__) && defined(__STRICT_ANSI__)
   return UTEST_CAST(utest_int64_t, clock()) * 1000000000 / CLOCKS_PER_SEC;
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) ||    \


### PR DESCRIPTION
>utest.h:336:10: runtime error: signed integer overflow: 3428234564152 * 1000000000 cannot be represented in type 'utest_int64_t' (aka 'long long')

Fix signed integer overflow by dividing by the frequency first.