### PR TITLE
Use __auto_type for GCC. __typeof__(x + 0) expr eval to different type then x.

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -2,3 +2,15 @@
 
 #define UTEST_TEST_SUITE c
 #include "test_shared.h"
+
+UTEST(c_type_eval, preserves_narrow_unsigned_type) {
+  uint8_t narrow = 1;
+  size_t wide = 1;
+  EXPECT_EQ(narrow, wide);
+}
+
+UTEST(c_type_eval, arrays_decay_to_pointers) {
+  int left[] = {1};
+  int right[] = {1};
+  EXPECT_NE(left, right);
+}

--- a/test/test98.cpp
+++ b/test/test98.cpp
@@ -2,3 +2,11 @@
 
 #define UTEST_TEST_SUITE cpp98
 #include "test_shared.h"
+
+#if __cplusplus < 201103L
+UTEST(cpp98_type_eval, arrays_decay_to_pointers) {
+  int left[] = {1};
+  int right[] = {1};
+  EXPECT_NE(left, right);
+}
+#endif

--- a/utest.h
+++ b/utest.h
@@ -724,6 +724,7 @@ utest_type_printer(long long unsigned int i) {
 #define utest_type_printer(val)                                                \
   UTEST_PRINTF(                                                                \
       _Generic((val),                                                          \
+      char: "%d",                                                              \
       signed char: "%d",                                                       \
       unsigned char: "%u",                                                     \
       short: "%d",                                                             \
@@ -797,7 +798,11 @@ utest_type_printer(long long unsigned int i) {
           _Pragma("clang diagnostic pop")
 /* clang-format on */
 #else
+#if defined(__TINYC__)
 #define UTEST_AUTO(x) __typeof__(x + 0)
+#else
+#define UTEST_AUTO(x) __typeof__((void)0, (x))
+#endif
 #endif
 
 #else


### PR DESCRIPTION
Hi,

Adding "+ 0" results in type change (implicit type conversion caused by arithmetic operation).
Testcase:

```
#include "utest.h"

UTEST(type_eval, plus_int_zero)
{
    uint8_t a = 1;
    size_t b = 1;

    EXPECT_EQ(a, b);
}

UTEST_MAIN()
```

```console
gcc problem.c -Wall -Wextra -pedantic
In file included from problem.c:1:
problem.c: In function ‘utest_run_type_eval_plus_int_zero’:
utest.h:826:42: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  826 | #define EXPECT_EQ(x, y) UTEST_COND(x, y, ==, "", 0)
      |                                          ^~
utest.h:783:18: note: in definition of macro ‘UTEST_COND’
  783 |     if (!((xEval)cond(yEval))) {                                               \
      |                  ^~~~
problem.c:8:5: note: in expansion of macro ‘EXPECT_EQ’
    8 |     EXPECT_EQ(a, b);
      | 
```

Not sure why originally __auto_type was used only for CLANG (as I understand its GNU GCC ext. https://www.gnu.org/software/c-intro-and-ref/manual/html_node/Auto-Type.html)