### PR TITLE
minor: enable macros for generic types

### DIFF
--- a/test/test11.cpp
+++ b/test/test11.cpp
@@ -359,7 +359,7 @@ struct SomeStruct {
 };
 
 UTEST(cpp11, CustomType) {
-  SomeStruct s1{3};
-  SomeStruct s2{4};
+  SomeStruct s1 = {3};
+  SomeStruct s2 = {4};
   EXPECT_LT(s1, s2);
 }

--- a/test/test11.cpp
+++ b/test/test11.cpp
@@ -350,3 +350,16 @@ UTEST(cpp11, Null) {
 }
 
 #endif
+
+struct SomeStruct {
+  int a;
+  constexpr bool operator<(const SomeStruct &other) const {
+    return a < other.a;
+  }
+};
+
+UTEST(cpp11, CustomType) {
+  SomeStruct s1{3};
+  SomeStruct s2{4};
+  EXPECT_LT(s1, s2);
+}

--- a/test/test11.cpp
+++ b/test/test11.cpp
@@ -353,7 +353,7 @@ UTEST(cpp11, Null) {
 
 struct SomeStruct {
   int a;
-  constexpr bool operator<(const SomeStruct &other) const {
+  bool operator<(const SomeStruct &other) const {
     return a < other.a;
   }
 };

--- a/test/test14.cpp
+++ b/test/test14.cpp
@@ -350,3 +350,16 @@ UTEST(cpp14, Null) {
 }
 
 #endif
+
+struct SomeStruct {
+  int a;
+  constexpr bool operator<(const SomeStruct &other) const {
+    return a < other.a;
+  }
+};
+
+UTEST(cpp14, CustomType) {
+  SomeStruct s1{3};
+  SomeStruct s2{4};
+  EXPECT_LT(s1, s2);
+}

--- a/test/test14.cpp
+++ b/test/test14.cpp
@@ -353,7 +353,7 @@ UTEST(cpp14, Null) {
 
 struct SomeStruct {
   int a;
-  constexpr bool operator<(const SomeStruct &other) const {
+  bool operator<(const SomeStruct &other) const {
     return a < other.a;
   }
 };

--- a/test/test14.cpp
+++ b/test/test14.cpp
@@ -359,7 +359,7 @@ struct SomeStruct {
 };
 
 UTEST(cpp14, CustomType) {
-  SomeStruct s1{3};
-  SomeStruct s2{4};
+  SomeStruct s1 = {3};
+  SomeStruct s2 = {4};
   EXPECT_LT(s1, s2);
 }

--- a/test/test17.cpp
+++ b/test/test17.cpp
@@ -350,3 +350,16 @@ UTEST(cpp17, Null) {
 }
 
 #endif
+
+struct SomeStruct {
+  int a;
+  constexpr bool operator<(const SomeStruct &other) const {
+    return a < other.a;
+  }
+};
+
+UTEST(cpp17, CustomType) {
+  SomeStruct s1{3};
+  SomeStruct s2{4};
+  EXPECT_LT(s1, s2);
+}

--- a/test/test17.cpp
+++ b/test/test17.cpp
@@ -359,7 +359,7 @@ struct SomeStruct {
 };
 
 UTEST(cpp17, CustomType) {
-  SomeStruct s1{3};
-  SomeStruct s2{4};
+  SomeStruct s1 = {3};
+  SomeStruct s2 = {4};
   EXPECT_LT(s1, s2);
 }

--- a/test/test17.cpp
+++ b/test/test17.cpp
@@ -353,7 +353,7 @@ UTEST(cpp17, Null) {
 
 struct SomeStruct {
   int a;
-  constexpr bool operator<(const SomeStruct &other) const {
+  bool operator<(const SomeStruct &other) const {
     return a < other.a;
   }
 };

--- a/utest.h
+++ b/utest.h
@@ -698,7 +698,7 @@ utest_type_printer(long long unsigned int i) {
 #endif
 
 #if defined(__cplusplus) && (__cplusplus >= 201103L)
-#define UTEST_AUTO(x) auto
+#define UTEST_AUTO(x) const auto&
 #elif !defined(__cplusplus)
 
 #if defined(__clang__)

--- a/utest.h
+++ b/utest.h
@@ -537,7 +537,7 @@ template <> struct utest_type_deducer<bool, false> {
 
 template <typename T> struct utest_type_deducer<const T *, false> {
   static void _(const T *t) {
-    UTEST_PRINTF("%p", static_cast<void *>(const_cast<T *>(t)));
+    UTEST_PRINTF("%p", static_cast<const void *>(t));
   }
 };
 
@@ -551,6 +551,13 @@ template <typename T> struct utest_type_deducer<T, true> {
   }
 };
 
+// default printer for all other objects (specialize for custom printing)
+template <typename T> struct utest_type_deducer<T, false> {
+  static void _(const T& t) {
+    UTEST_PRINTF("(object %p)", static_cast<const void*>(&t));
+  }
+};
+
 template <> struct utest_type_deducer<std::nullptr_t, false> {
   static void _(std::nullptr_t t) {
     UTEST_PRINTF("%p", static_cast<void *>(t));
@@ -558,7 +565,7 @@ template <> struct utest_type_deducer<std::nullptr_t, false> {
 };
 
 template <typename T>
-UTEST_WEAK UTEST_OVERLOADABLE void utest_type_printer(const T t) {
+UTEST_WEAK UTEST_OVERLOADABLE void utest_type_printer(const T& t) {
   utest_type_deducer<T>::_(t);
 }
 


### PR DESCRIPTION
Love this project so much! This PR:
- Adds a default implementation for `struct utest_type_deducer<T, false>` so that custom structs in C++ with proper overloaded operators can still enjoy all the UTEST macros without error. Previously, one could not use macros like `EXPECT_LT` without custom template specializations of `utest_type_deducer`.
- Removed an unnecessary `const_cast`
- Changed the printing function to pass by reference. This may have some very small performance overhead for small primitives if C++ if the compiler doesn't optimize it away, but consistency for all types is probably nice.
- Changed `UTEST_AUTO` to be a const auto reference. This not only accepts both lvalues and rvalues (temporaries) but it also now allows utest macros to work for structs that are not copy constructible.

Discussion:
In a future PR, it could be nice to check if a struct is forgettable via the concept [`std::formattable`](https://en.cppreference.com/w/cpp/utility/format/formattable.html) available in C++23. Then one could call `std::format` on the provided struct instead of printing `(object [pointer])` as I do by default for now for max compatibility.