### PR TITLE
Sort tests by source location for deterministic TU order

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,6 +108,7 @@ endfunction()
 # C files — each compiled under a specific C standard.
 utest_set_c_flags(main.c  "-std=gnu89")
 utest_set_c_flags(test.c  "-std=gnu89")
+utest_set_c_flags(order.c "-std=gnu89")
 utest_set_c_flags(test99.c "-std=c99")
 
 list(FIND CMAKE_C_COMPILE_FEATURES c_std_11 IDX)
@@ -138,6 +139,7 @@ set(UTEST_TEST_SOURCES
   test_shared.h
   main.c
   test.c
+  order.c
   test99.c
   test11.c
   test.cpp

--- a/test/main.c
+++ b/test/main.c
@@ -37,6 +37,70 @@
 
 // TODO: Broken under MINGW for some reason.
 #if !(defined(__MINGW32__) || defined(__MINGW64__))
+
+// 64k should be enough for anyone
+#define MAX_CHARS (64 * 1024)
+
+static size_t utest_cmdline_not_found(void) { return UTEST_CAST(size_t, -1); }
+
+static void utest_cmdline_strip_newline(char *buffer) {
+  size_t index;
+
+  for (index = 0; '\0' != buffer[index]; index++) {
+    if ((buffer[index] == '\r') || (buffer[index] == '\n')) {
+      buffer[index] = '\0';
+      break;
+    }
+  }
+}
+
+static int utest_cmdline_list_positions(const char *const *names,
+                                        size_t names_length,
+                                        size_t *positions) {
+  struct subprocess_s process;
+  const char *command[3] = {"utest_test", "--list-tests", 0};
+  int return_code;
+  FILE *stdout_file;
+  size_t index;
+  size_t line;
+  char buffer[MAX_CHARS] = {0};
+
+  for (index = 0; index < names_length; index++) {
+    positions[index] = utest_cmdline_not_found();
+  }
+
+  if (0 != subprocess_create(command, subprocess_option_combined_stdout_stderr,
+                             &process)) {
+    return 1;
+  }
+
+  stdout_file = subprocess_stdout(&process);
+  line = 0;
+
+  while (buffer == fgets(buffer, MAX_CHARS, stdout_file)) {
+    utest_cmdline_strip_newline(buffer);
+
+    for (index = 0; index < names_length; index++) {
+      if (0 == strcmp(buffer, names[index])) {
+        positions[index] = line;
+      }
+    }
+
+    line++;
+  }
+
+  if (0 != subprocess_join(&process, &return_code)) {
+    (void)subprocess_destroy(&process);
+    return 1;
+  }
+
+  if (0 != subprocess_destroy(&process)) {
+    return 1;
+  }
+
+  return return_code;
+}
+
 UTEST(utest_cmdline, filter_with_list) {
   struct subprocess_s process;
   const char *command[3] = {"utest_test", "--list-tests", 0};
@@ -45,8 +109,6 @@ UTEST(utest_cmdline, filter_with_list) {
   size_t kndex;
   char *hits;
 
-// 64k should be enough for anyone
-#define MAX_CHARS (64 * 1024)
   char buffer[MAX_CHARS] = {0};
 
   hits = (char *)malloc(utest_state.tests_length);
@@ -68,12 +130,7 @@ UTEST(utest_cmdline, filter_with_list) {
 #endif
 
     // First wipe out the newlines from the fgets.
-    for (kndex = 0;; kndex++) {
-      if ((buffer[kndex] == '\r') || (buffer[kndex] == '\n')) {
-        buffer[kndex] = '\0';
-        break;
-      }
-    }
+    utest_cmdline_strip_newline(buffer);
 
     // Record the hit for listed test.
     for (kndex = 0; kndex < utest_state.tests_length; kndex++) {
@@ -102,6 +159,46 @@ UTEST(utest_cmdline, filter_with_list) {
   }
 
   free(hits);
+}
+
+UTEST(utest_cmdline, list_tests_same_line_sorted_by_name) {
+  const char *const names[2] = {"utest_order_same_line.a",
+                                "utest_order_same_line.b"};
+  size_t positions[2];
+
+  ASSERT_EQ(0, utest_cmdline_list_positions(
+                   names, sizeof names / sizeof names[0], positions));
+  ASSERT_NE(utest_cmdline_not_found(), positions[0]);
+  ASSERT_NE(utest_cmdline_not_found(), positions[1]);
+  ASSERT_LT(positions[0], positions[1]);
+}
+
+UTEST(utest_cmdline, list_tests_same_line_sorted_by_index) {
+  const char *const names[12] = {"utest_order_indexed_fixture.many/0",
+                                 "utest_order_indexed_fixture.many/1",
+                                 "utest_order_indexed_fixture.many/2",
+                                 "utest_order_indexed_fixture.many/3",
+                                 "utest_order_indexed_fixture.many/4",
+                                 "utest_order_indexed_fixture.many/5",
+                                 "utest_order_indexed_fixture.many/6",
+                                 "utest_order_indexed_fixture.many/7",
+                                 "utest_order_indexed_fixture.many/8",
+                                 "utest_order_indexed_fixture.many/9",
+                                 "utest_order_indexed_fixture.many/10",
+                                 "utest_order_indexed_fixture.many/11"};
+  size_t positions[12];
+  size_t index;
+
+  ASSERT_EQ(0, utest_cmdline_list_positions(
+                   names, sizeof names / sizeof names[0], positions));
+
+  for (index = 0; index < sizeof positions / sizeof positions[0]; index++) {
+    ASSERT_NE(utest_cmdline_not_found(), positions[index]);
+  }
+
+  for (index = 1; index < sizeof positions / sizeof positions[0]; index++) {
+    ASSERT_LT(positions[index - 1], positions[index]);
+  }
 }
 #endif
 

--- a/test/order.c
+++ b/test/order.c
@@ -1,0 +1,53 @@
+/*
+   This is free and unencumbered software released into the public domain.
+
+   Anyone is free to copy, modify, publish, use, compile, sell, or
+   distribute this software, either in source code form or as a compiled
+   binary, for any purpose, commercial or non-commercial, and by any
+   means.
+
+   In jurisdictions that recognize copyright laws, the author or authors
+   of this software dedicate any and all copyright interest in the
+   software to the public domain. We make this dedication for the benefit
+   of the public at large and to the detriment of our heirs and
+   successors. We intend this dedication to be an overt act of
+   relinquishment in perpetuity of all present and future rights to this
+   software under copyright law.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+   OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+   ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+   OTHER DEALINGS IN THE SOFTWARE.
+
+   For more information, please refer to <http://unlicense.org/>
+*/
+
+#include "utest.h"
+
+struct utest_order_indexed_fixture {
+  int unused;
+};
+
+UTEST_I_SETUP(utest_order_indexed_fixture) {
+  (void)utest_fixture;
+  (void)utest_index;
+  ASSERT_TRUE(1);
+}
+
+UTEST_I_TEARDOWN(utest_order_indexed_fixture) {
+  (void)utest_fixture;
+  (void)utest_index;
+  ASSERT_TRUE(1);
+}
+
+UTEST_I(utest_order_indexed_fixture, many, 12) {
+  (void)utest_fixture;
+  ASSERT_TRUE(1);
+}
+
+// clang-format off
+UTEST(utest_order_same_line, b) { ASSERT_TRUE(1); } UTEST(utest_order_same_line, a) { ASSERT_TRUE(1); }
+// clang-format on

--- a/utest.h
+++ b/utest.h
@@ -378,6 +378,8 @@ struct utest_test_state_s {
   utest_testcase_t func;
   size_t index;
   char *name;
+  const char *file;
+  size_t line;
 };
 
 struct utest_state_s {
@@ -1222,6 +1224,8 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
       utest_state.tests[index].func = &utest_##SET##_##NAME;                   \
       utest_state.tests[index].name = name;                                    \
       utest_state.tests[index].index = 0;                                      \
+      utest_state.tests[index].file = __FILE__;                                \
+      utest_state.tests[index].line = __LINE__;                                \
       UTEST_SNPRINTF(name, name_size, "%s", name_part);                        \
     } else {                                                                   \
       if (utest_state.tests) {                                                 \
@@ -1276,6 +1280,8 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
       utest_state.tests[index].func = &utest_f_##FIXTURE##_##NAME;             \
       utest_state.tests[index].name = name;                                    \
       utest_state.tests[index].index = 0;                                      \
+      utest_state.tests[index].file = __FILE__;                                \
+      utest_state.tests[index].line = __LINE__;                                \
       UTEST_SNPRINTF(name, name_size, "%s", name_part);                        \
     } else {                                                                   \
       if (utest_state.tests) {                                                 \
@@ -1331,6 +1337,8 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
         utest_state.tests[index].func = &utest_i_##FIXTURE##_##NAME##_##INDEX; \
         utest_state.tests[index].index = i;                                    \
         utest_state.tests[index].name = name;                                  \
+        utest_state.tests[index].file = __FILE__;                              \
+        utest_state.tests[index].line = __LINE__;                              \
         iUp = UTEST_CAST(utest_uint64_t, i);                                   \
         UTEST_SNPRINTF(name, name_size, "%s/%" UTEST_PRIu64, name_part, iUp);  \
       } else {                                                                 \
@@ -1458,6 +1466,57 @@ UTEST_WEAK int utest_should_filter_test(const char *filter,
   return 0;
 }
 
+/* Sort tests by definition location to avoid translation unit registration
+   order. The index/name tie-breakers make same-line tests deterministic. */
+UTEST_WEAK
+int utest_test_state_cmp(const void *lhs, const void *rhs);
+UTEST_WEAK int utest_test_state_cmp(const void *lhs, const void *rhs) {
+  const struct utest_test_state_s *const lhs_test =
+      UTEST_PTR_CAST(const struct utest_test_state_s *, lhs);
+  const struct utest_test_state_s *const rhs_test =
+      UTEST_PTR_CAST(const struct utest_test_state_s *, rhs);
+  int result = 0;
+
+  if (lhs_test->file != rhs_test->file) {
+    result = strcmp(lhs_test->file, rhs_test->file);
+    if (0 != result) {
+      return result;
+    }
+  }
+
+  if (lhs_test->line < rhs_test->line) {
+    return -1;
+  }
+
+  if (lhs_test->line > rhs_test->line) {
+    return 1;
+  }
+
+  if (lhs_test->index < rhs_test->index) {
+    return -1;
+  }
+
+  if (lhs_test->index > rhs_test->index) {
+    return 1;
+  }
+
+  if (lhs_test->name != rhs_test->name) {
+    result = strcmp(lhs_test->name, rhs_test->name);
+    if (0 != result) {
+      return result;
+    }
+  }
+
+  return 0;
+}
+
+static UTEST_INLINE void utest_sort_tests(void) {
+  if (utest_state.tests && (utest_state.tests_length > 1)) {
+    qsort(UTEST_PTR_CAST(void *, utest_state.tests), utest_state.tests_length,
+          sizeof(utest_state.tests[0]), utest_test_state_cmp);
+  }
+}
+
 static UTEST_INLINE FILE *utest_fopen(const char *filename, const char *mode) {
 #ifdef _MSC_VER
   FILE *file;
@@ -1532,6 +1591,7 @@ int utest_main(int argc, const char *const argv[]) {
                UTEST_STRNCMP(argv[index], output_str, strlen(output_str))) {
       utest_state.output = utest_fopen(argv[index] + strlen(output_str), "w+");
     } else if (0 == UTEST_STRNCMP(argv[index], list_str, strlen(list_str))) {
+      utest_sort_tests();
       for (index = 0; index < utest_state.tests_length; index++) {
         UTEST_PRINTF("%s\n", utest_state.tests[index].name);
       }
@@ -1560,6 +1620,8 @@ int utest_main(int argc, const char *const argv[]) {
       random_order = 1;
     }
   }
+
+  utest_sort_tests();
 
   if (random_order) {
     // Use Fisher-Yates with the Durstenfield's version to randomly re-order the


### PR DESCRIPTION
## Summary
- Record each test's `__FILE__`/`__LINE__` at registration time.
- Sort the registered test list by file, line, index, then name before listing/running tests.
- Keep seeded `--random-order` deterministic by shuffling from the sorted base order.
- Add coverage for same-line test tie-breaking and indexed test numeric order.

## Cost notes
- Uses libc `qsort`; no new dependencies.
- 64-bit struct size grows by 16 bytes/test (`24B -> 40B`).
- Local benchmark (`cc -O2`, Apple clang 17, arm64): current ~1,841-test suite sorted in ~101 µs avg; 10k tests ~0.93 ms; 100k tests ~12.4 ms.

## Tests
- `cmake --build /tmp/utest-build-sort`
- `ctest --test-dir /tmp/utest-build-sort --output-on-failure`

---

🧙 Conjured by AI via [pi.dev](https://pi.dev/) using gpt-5.5