### PR TITLE
Fix ASSERT_MEMEQ_MSG invoking the wrong underlying macro

### DIFF
--- a/utest.h
+++ b/utest.h
@@ -982,7 +982,7 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
 #define EXPECT_MEMEQ(x, y, s) UTEST_MEMEQ(x, y, s, "", 0)
 #define EXPECT_MEMEQ_MSG(x, y, s, msg) UTEST_MEMEQ(x, y, s, msg, 0)
 #define ASSERT_MEMEQ(x, y, s) UTEST_MEMEQ(x, y, s, "", 1)
-#define ASSERT_MEMEQ_MSG(x, y, s, msg) UTEST_STREQ(x, y, s, msg, 1)
+#define ASSERT_MEMEQ_MSG(x, y, s, msg) UTEST_MEMEQ(x, y, s, msg, 1)
 
 #define UTEST_STREQ(x, y, msg, is_assert)                                      \
   UTEST_SURPRESS_WARNING_BEGIN do {                                            \


### PR DESCRIPTION
`ASSERT_MEMEQ_MSG` (introduced in #176) expands to `UTEST_STREQ(x, y, s, msg, 1)`, but `UTEST_STREQ` only takes 4 parameters (`x, y, msg, is_assert`) while 5 arguments are passed. This is a guaranteed compile error on any use of `ASSERT_MEMEQ_MSG`:

```
error: macro "UTEST_STREQ" passed 5 arguments, but takes just 4
error: 'UTEST_STREQ' undeclared (first use in this function)
```

This fix changes it to invoke `UTEST_MEMEQ` instead, matching the sibling macros `EXPECT_MEMEQ_MSG`/`ASSERT_MEMEQ`/`EXPECT_MEMEQ` which are all defined correctly.

Note `EXPECT_MEMEQ_MSG` is unaffected -- only `ASSERT_MEMEQ_MSG` has the wrong macro name.

**Verification:** compiled a minimal reproduction with mingw64 gcc 8.1.0 (`-Wall -Wextra`, zero warnings after the fix). Before the fix, the reproduction fails to compile with the error above. After the fix: `ASSERT_MEMEQ_MSG` on equal buffers passes, and `EXPECT_MEMEQ_MSG` on deliberately unequal buffers still correctly fails and prints the expected/actual hex bytes plus the custom message.

`test/test_shared.h` currently covers `ASSERT_MEMEQ`/`EXPECT_MEMEQ` (no-message variants) but has no test for the `_MSG` variants, which is why this was never caught.