### PR TITLE
Restore caller MSVC warning state

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,46 @@ include(CTest)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
 
+# Verify that including utest.h restores the caller's MSVC warning state.
+# The undefined-macro warning is enabled as an error before the include and
+# deliberately triggered afterwards. The probe must therefore fail to compile;
+# if it succeeds, the header leaked its internal suppression into the source.
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
+  set(UTEST_WARNING_STATE_PRAGMA "#pragma warning(error : 4668)")
+  set(UTEST_WARNING_STATE_EXPECTED_ERROR "C4668")
+elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" AND
+       CMAKE_C_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+  set(UTEST_WARNING_STATE_PRAGMA
+      "#pragma clang diagnostic error \"-Wundef\"")
+  set(UTEST_WARNING_STATE_EXPECTED_ERROR "Wundef")
+endif()
+
+if(DEFINED UTEST_WARNING_STATE_PRAGMA)
+  file(TO_CMAKE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../utest.h"
+       UTEST_HEADER_PATH)
+  set(UTEST_WARNING_STATE_PROBE
+      "${CMAKE_CURRENT_BINARY_DIR}/warning_state_probe.c")
+  file(WRITE "${UTEST_WARNING_STATE_PROBE}"
+    "${UTEST_WARNING_STATE_PRAGMA}\n"
+    "#include \"${UTEST_HEADER_PATH}\"\n"
+    "#if UTEST_UNDEFINED_WARNING_STATE_PROBE\n"
+    "#endif\n"
+    "int main(void) { return 0; }\n")
+  try_compile(UTEST_WARNING_STATE_PROBE_COMPILES
+    "${CMAKE_CURRENT_BINARY_DIR}/warning_state_probe"
+    SOURCES "${UTEST_WARNING_STATE_PROBE}"
+    CMAKE_FLAGS "-DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY"
+    OUTPUT_VARIABLE UTEST_WARNING_STATE_PROBE_OUTPUT)
+  if(UTEST_WARNING_STATE_PROBE_COMPILES)
+    message(FATAL_ERROR "utest.h leaked its MSVC warning state")
+  elseif(NOT UTEST_WARNING_STATE_PROBE_OUTPUT MATCHES
+             "${UTEST_WARNING_STATE_EXPECTED_ERROR}")
+    message(FATAL_ERROR
+      "MSVC warning-state probe failed unexpectedly:\n"
+      "${UTEST_WARNING_STATE_PROBE_OUTPUT}")
+  endif()
+endif()
+
 # Base warning flags and whether -std= flags are supported.
 # MSVC and clang-cl use /std: and don't accept -std=, so we skip
 # the standard flag for those compilers.

--- a/test/main.c
+++ b/test/main.c
@@ -33,13 +33,25 @@
 #endif
 #endif
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4710)
+#endif
 #include "subprocess.h"
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 // TODO: Broken under MINGW for some reason.
 #if !(defined(__MINGW32__) || defined(__MINGW64__))
 
 // 64k should be enough for anyone
 #define MAX_CHARS (64 * 1024)
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4711)
+#endif
 
 static size_t utest_cmdline_not_found(void) { return UTEST_CAST(size_t, -1); }
 
@@ -100,6 +112,10 @@ static int utest_cmdline_list_positions(const char *const *names,
 
   return return_code;
 }
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 UTEST(utest_cmdline, filter_with_list) {
   struct subprocess_s process;

--- a/test/test_shared.h
+++ b/test/test_shared.h
@@ -443,11 +443,18 @@ UTEST_TEST(Near) {
 #if defined(MEMORY_SANITIZER)
 __attribute__((no_sanitize("memory")))
 #endif
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4710)
+#endif
 static int UTEST_TEST_FIXTURE(foo)(int bar) {
   if (bar == 1)
     throw std::range_error("bad bar");
   return bar + 1;
 }
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 UTEST_TEST(Exception) {
   EXPECT_EXCEPTION(UTEST_TEST_FIXTURE(foo)(1), std::range_error);

--- a/utest.h
+++ b/utest.h
@@ -34,6 +34,8 @@
 #define SHEREDOM_UTEST_H_INCLUDED
 
 #ifdef _MSC_VER
+#pragma warning(push)
+
 /*
    Disable warning about not inlining 'inline' functions.
 */
@@ -94,6 +96,7 @@ typedef uint32_t utest_uint32_t;
 #endif
 
 #include <stddef.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -302,8 +305,8 @@ UTEST_C_FUNC __declspec(dllimport) int __stdcall QueryPerformanceFrequency(
     uninteresting, but for some reason MSVC's behaviour is to warn about
     including this system header. That *is* interesting
 */
-#pragma warning(disable : 4820)
 #pragma warning(push, 1)
+#pragma warning(disable : 4820)
 #include <io.h>
 #pragma warning(pop)
 #define UTEST_COLOUR_OUTPUT() (_isatty(_fileno(stdout)))
@@ -411,12 +414,21 @@ UTEST_EXTERN struct utest_state_s utest_state;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvariadic-macros"
 #pragma clang diagnostic ignored "-Wc++98-compat-pedantic"
+#if __has_warning("-Wformat-nonliteral")
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
 #endif
+#endif
+#if defined(_MSC_VER)
+UTEST_C_FUNC __declspec(noinline) int utest_printf_msvc(const char *format,
+                                                       ...);
+#define UTEST_PRINTF(...) ((void)utest_printf_msvc(__VA_ARGS__))
+#else
 #define UTEST_PRINTF(...)                                                      \
   if (utest_state.output) {                                                    \
     fprintf(utest_state.output, __VA_ARGS__);                                  \
   }                                                                            \
   printf(__VA_ARGS__)
+#endif
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
@@ -1215,6 +1227,15 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
   UTEST_EXCEPTION_WITH_MESSAGE(x, exception_type, exception_message, msg, 1)
 #endif
 
+#if defined(_MSC_VER)
+#define UTEST_SURPRESS_MSVC_WARNINGS_BEGIN                                     \
+  __pragma(warning(push)) __pragma(warning(disable : 4711))
+#define UTEST_SURPRESS_MSVC_WARNINGS_END __pragma(warning(pop))
+#else
+#define UTEST_SURPRESS_MSVC_WARNINGS_BEGIN
+#define UTEST_SURPRESS_MSVC_WARNINGS_END
+#endif
+
 #if defined(__clang__)
 #if __has_warning("-Wunsafe-buffer-usage-in-libc-call")
 #define UTEST_SURPRESS_UNSAFE_BUFFER_USAGE                                     \
@@ -1234,20 +1255,25 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
 #define UTEST_SURPRESS_GLOBAL_CONSTRUCTORS
 #endif
 
-#define UTEST_SURPRESS_WARNINGS_BEGIN                                          \
+#define UTEST_SURPRESS_COMPILER_WARNINGS_BEGIN                                 \
   _Pragma("clang diagnostic push")                                             \
       UTEST_SURPRESS_UNSAFE_BUFFER_USAGE                                       \
           UTEST_SURPRESS_GLOBAL_CONSTRUCTORS
-#define UTEST_SURPRESS_WARNINGS_END _Pragma("clang diagnostic pop")
+#define UTEST_SURPRESS_COMPILER_WARNINGS_END _Pragma("clang diagnostic pop")
 #elif defined(__GNUC__) && __GNUC__ >= 8 && defined(__cplusplus)
-#define UTEST_SURPRESS_WARNINGS_BEGIN                                          \
+#define UTEST_SURPRESS_COMPILER_WARNINGS_BEGIN                                 \
   _Pragma("GCC diagnostic push")                                               \
       _Pragma("GCC diagnostic ignored \"-Wclass-memaccess\"")
-#define UTEST_SURPRESS_WARNINGS_END _Pragma("GCC diagnostic pop")
+#define UTEST_SURPRESS_COMPILER_WARNINGS_END _Pragma("GCC diagnostic pop")
 #else
-#define UTEST_SURPRESS_WARNINGS_BEGIN
-#define UTEST_SURPRESS_WARNINGS_END
+#define UTEST_SURPRESS_COMPILER_WARNINGS_BEGIN
+#define UTEST_SURPRESS_COMPILER_WARNINGS_END
 #endif
+
+#define UTEST_SURPRESS_WARNINGS_BEGIN                                          \
+  UTEST_SURPRESS_MSVC_WARNINGS_BEGIN UTEST_SURPRESS_COMPILER_WARNINGS_BEGIN
+#define UTEST_SURPRESS_WARNINGS_END                                            \
+  UTEST_SURPRESS_COMPILER_WARNINGS_END UTEST_SURPRESS_MSVC_WARNINGS_END
 
 #define UTEST(SET, NAME)                                                       \
   UTEST_SURPRESS_WARNINGS_BEGIN                                                \
@@ -1861,7 +1887,42 @@ cleanup:
    data without having to use the UTEST_MAIN macro, thus allowing them to write
    their own main() function.
 */
+#if defined(_MSC_VER)
+#if defined(__clang__)
+#define UTEST_DEFINE_PRINTF_CLANG_BEGIN                                        \
+  _Pragma("clang diagnostic push")                                             \
+      _Pragma("clang diagnostic ignored \"-Wformat-nonliteral\"")
+#define UTEST_DEFINE_PRINTF_CLANG_END _Pragma("clang diagnostic pop")
+#else
+#define UTEST_DEFINE_PRINTF_CLANG_BEGIN
+#define UTEST_DEFINE_PRINTF_CLANG_END
+#endif
+
+#define UTEST_DEFINE_PRINTF_HELPER()                                           \
+  __pragma(warning(push)) __pragma(warning(disable : 4710))                    \
+      UTEST_DEFINE_PRINTF_CLANG_BEGIN UTEST_C_FUNC __declspec(noinline) int    \
+      utest_printf_msvc(const char *format, ...) {                             \
+    int result;                                                                \
+    va_list args;                                                              \
+    if (utest_state.output) {                                                  \
+      va_start(args, format);                                                  \
+      (void)vfprintf(utest_state.output, format, args);                        \
+      va_end(args);                                                            \
+    }                                                                          \
+    va_start(args, format);                                                    \
+    result = vfprintf(stdout, format, args);                                   \
+    va_end(args);                                                              \
+    return result;                                                             \
+  }                                                                            \
+  UTEST_DEFINE_PRINTF_CLANG_END __pragma(warning(pop))
+
+#define UTEST_STATE()                                                          \
+  struct utest_state_s utest_state = {0, 0, 0};                                \
+  UTEST_DEFINE_PRINTF_HELPER()                                                 \
+  extern int utest_state_requires_trailing_semicolon
+#else
 #define UTEST_STATE() struct utest_state_s utest_state = {0, 0, 0}
+#endif
 
 /*
    define a main() function to call into utest.h and start executing tests! A
@@ -1875,5 +1936,9 @@ cleanup:
   int main(int argc, const char *const argv[]) {                               \
     return utest_main(argc, argv);                                             \
   }
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 #endif /* SHEREDOM_UTEST_H_INCLUDED */


### PR DESCRIPTION
## Summary
- supersede #179 with a narrower fix
- save the caller’s MSVC warning state before applying `utest.h`’s internal suppressions and restore it at the end of the header
- nest the system-header warning-level scopes correctly, including the `io.h` scope
- suppress C4711 only around generated test-registration code after the caller’s state has been restored
- route `UTEST_PRINTF` through one noinline MSVC adapter so generated assertions do not produce LTCG C4710 diagnostics, while preserving existing output behavior
- isolate unrelated C4710/C4711 diagnostics from test-only helpers and vendored `subprocess.h`
- add configure-time MSVC and clang-cl probes that detect warning-state leaks

## Testing
- full GitHub Actions matrix passes: 28 jobs across Ubuntu, Windows, and macOS
- Clang 19 release build and all 10 tests locally
- GCC 14 release build and all 4 tests locally
- fake-MSVC preprocessing check
- `git diff --check`

Unlike #179, this avoids replacing every output call and defines only one targeted MSVC output adapter through `UTEST_STATE`.

---

🧙 Conjured by AI via [pi.dev](https://pi.dev/) using gpt-5.6-sol