### PR TITLE
Update checkout action to Node.js 24

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Create Build Environment
       run: cmake -E make_directory ${{github.workspace}}/build


### PR DESCRIPTION
## Summary
- update `actions/checkout` from v4 to v7
- remove the repeated Node.js 20 deprecation annotations from every CI matrix job

## Testing
- workflow-only one-line version update
- `git diff --check`

---

🧙 Conjured by AI via [pi.dev](https://pi.dev/) using gpt-5.6-sol