### PR TITLE
Fix 32-bit builds under -Wpedantic

### DIFF
--- a/utest.h
+++ b/utest.h
@@ -203,13 +203,40 @@ UTEST_C_FUNC __declspec(dllimport) int __stdcall QueryPerformanceFrequency(
 #endif
 
 #if defined(_MSC_VER) && (_MSC_VER < 1920)
-#define UTEST_PRId64 ".0f"
-#define UTEST_PRIu64 ".0f"
+#define UTEST_PRId64 "I64d"
+#define UTEST_PRIu64 "I64u"
+#define UTEST_INT64_ARG(x) (x)
+#define UTEST_UINT64_ARG(x) (x)
 #else
+/* NetBSD hides the PRI macros from C++ before C++11 unless this is defined. */
+#if defined(__cplusplus) && !defined(__STDC_FORMAT_MACROS)
+#define __STDC_FORMAT_MACROS 1
+#endif
 #include <inttypes.h>
+#include <limits.h>
 
+/* Where uint64_t is not unsigned long the PRI macros use the ll length
+   modifier, which C90 and C++98 do not have. Only those builds print through
+   double instead; every other target keeps using the macros unchanged.
+
+   _MSC_VER is listed explicitly because neither of the other tests recognises
+   it: Windows is LLP64, so unsigned long is 32 bits even on x64, and MSVC
+   reports __cplusplus as 199711L without /Zc:__cplusplus and defines no
+   __STDC_VERSION__ in its default C mode. Anything reaching here is 1920 or
+   newer and prints 64-bit integers fine. */
+#if defined(_MSC_VER) || (ULONG_MAX > 0xfffffffful) ||                         \
+    (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)) ||            \
+    (defined(__cplusplus) && (__cplusplus >= 201103L))
+#define UTEST_PRId64 PRId64
+#define UTEST_PRIu64 PRIu64
+#define UTEST_INT64_ARG(x) (x)
+#define UTEST_UINT64_ARG(x) (x)
+#else
 #define UTEST_PRId64 ".0f"
 #define UTEST_PRIu64 ".0f"
+#define UTEST_INT64_ARG(x) UTEST_CAST(double, x)
+#define UTEST_UINT64_ARG(x) UTEST_CAST(double, x)
+#endif
 #endif
 
 #if defined(__cplusplus)
@@ -1414,7 +1441,7 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
         utest_state.tests[index].line = __LINE__;                              \
         iUp = UTEST_CAST(utest_uint64_t, i);                                   \
         UTEST_SNPRINTF(name, name_size, "%s/%" UTEST_PRIu64, name_part,        \
-                       UTEST_CAST(double, iUp));  \
+                       UTEST_UINT64_ARG(iUp));                                 \
       } else {                                                                 \
         if (utest_state.tests) {                                               \
           free(utest_state.tests);                                             \
@@ -1730,16 +1757,16 @@ int utest_main(int argc, const char *const argv[]) {
   }
 
   printf("%s[==========]%s Running %" UTEST_PRIu64 " test cases.\n",
-         colours[GREEN], colours[RESET], UTEST_CAST(double, ran_tests));
+         colours[GREEN], colours[RESET], UTEST_UINT64_ARG(ran_tests));
 
   if (utest_state.output) {
     fprintf(utest_state.output, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
     fprintf(utest_state.output,
             "<testsuites tests=\"%" UTEST_PRIu64 "\" name=\"All\">\n",
-            UTEST_CAST(double, ran_tests));
+            UTEST_UINT64_ARG(ran_tests));
     fprintf(utest_state.output,
             "<testsuite name=\"Tests\" tests=\"%" UTEST_PRIu64 "\">\n",
-            UTEST_CAST(double, ran_tests));
+            UTEST_UINT64_ARG(ran_tests));
   }
 
   for (index = 0; index < utest_state.tests_length; index++) {
@@ -1820,30 +1847,27 @@ int utest_main(int argc, const char *const argv[]) {
       if (UTEST_TEST_FAILURE == result) {
         printf("%s[  FAILED  ]%s %s (%" UTEST_PRId64 "%s)\n", colours[RED],
                colours[RESET], utest_state.tests[index].name,
-               UTEST_CAST(double, time),
-               units[unit_index]);
+               UTEST_INT64_ARG(time), units[unit_index]);
       } else if (UTEST_TEST_SKIPPED == result) {
         printf("%s[  SKIPPED ]%s %s (%" UTEST_PRId64 "%s)\n", colours[YELLOW],
                colours[RESET], utest_state.tests[index].name,
-               UTEST_CAST(double, time),
-               units[unit_index]);
+               UTEST_INT64_ARG(time), units[unit_index]);
       } else {
         printf("%s[       OK ]%s %s (%" UTEST_PRId64 "%s)\n", colours[GREEN],
                colours[RESET], utest_state.tests[index].name,
-               UTEST_CAST(double, time),
-               units[unit_index]);
+               UTEST_INT64_ARG(time), units[unit_index]);
       }
     }
   }
 
   printf("%s[==========]%s %" UTEST_PRIu64 " test cases ran.\n", colours[GREEN],
-         colours[RESET], UTEST_CAST(double, ran_tests));
+         colours[RESET], UTEST_UINT64_ARG(ran_tests));
   printf("%s[  PASSED  ]%s %" UTEST_PRIu64 " tests.\n", colours[GREEN],
-         colours[RESET], UTEST_CAST(double, ran_tests - failed - skipped));
+         colours[RESET], UTEST_UINT64_ARG(ran_tests - failed - skipped));
 
   if (0 != skipped) {
     printf("%s[  SKIPPED ]%s %" UTEST_PRIu64 " tests, listed below:\n",
-           colours[YELLOW], colours[RESET], UTEST_CAST(double, skipped));
+           colours[YELLOW], colours[RESET], UTEST_UINT64_ARG(skipped));
     for (index = 0; index < skipped_testcases_length; index++) {
       printf("%s[  SKIPPED ]%s %s\n", colours[YELLOW], colours[RESET],
              utest_state.tests[skipped_testcases[index]].name);
@@ -1852,7 +1876,7 @@ int utest_main(int argc, const char *const argv[]) {
 
   if (0 != failed) {
     printf("%s[  FAILED  ]%s %" UTEST_PRIu64 " tests, listed below:\n",
-           colours[RED], colours[RESET], UTEST_CAST(double, failed));
+           colours[RED], colours[RESET], UTEST_UINT64_ARG(failed));
     for (index = 0; index < failed_testcases_length; index++) {
       printf("%s[  FAILED  ]%s %s\n", colours[RED], colours[RESET],
              utest_state.tests[failed_testcases[index]].name);

--- a/utest.h
+++ b/utest.h
@@ -1444,7 +1444,7 @@ double utest_fabs(double d) {
     utest_uint64_t u;
   } both;
   both.d = d;
-  both.u &= ~((utest_uint64_t)1 << 63);
+  both.u &= ~(UTEST_CAST(utest_uint64_t, 1) << 63);
   return both.d;
 }
 
@@ -1457,8 +1457,8 @@ int utest_isnan(double d) {
     utest_uint64_t u;
   } both;
   both.d = d;
-  both.u &= ~((utest_uint64_t)1 << 63);
-  return both.u > ((utest_uint64_t)0x7ff00000 << 32);
+  both.u &= ~(UTEST_CAST(utest_uint64_t, 1) << 63);
+  return both.u > (UTEST_CAST(utest_uint64_t, 0x7ff00000) << 32);
 }
 
 #ifdef __clang__

--- a/utest.h
+++ b/utest.h
@@ -203,13 +203,13 @@ UTEST_C_FUNC __declspec(dllimport) int __stdcall QueryPerformanceFrequency(
 #endif
 
 #if defined(_MSC_VER) && (_MSC_VER < 1920)
-#define UTEST_PRId64 "I64d"
-#define UTEST_PRIu64 "I64u"
+#define UTEST_PRId64 ".0f"
+#define UTEST_PRIu64 ".0f"
 #else
 #include <inttypes.h>
 
-#define UTEST_PRId64 PRId64
-#define UTEST_PRIu64 PRIu64
+#define UTEST_PRId64 ".0f"
+#define UTEST_PRIu64 ".0f"
 #endif
 
 #if defined(__cplusplus)
@@ -1413,7 +1413,8 @@ utest_strncpy_gcc(char *const dst, const char *const src, const size_t size) {
         utest_state.tests[index].file = __FILE__;                              \
         utest_state.tests[index].line = __LINE__;                              \
         iUp = UTEST_CAST(utest_uint64_t, i);                                   \
-        UTEST_SNPRINTF(name, name_size, "%s/%" UTEST_PRIu64, name_part, iUp);  \
+        UTEST_SNPRINTF(name, name_size, "%s/%" UTEST_PRIu64, name_part,        \
+                       UTEST_CAST(double, iUp));  \
       } else {                                                                 \
         if (utest_state.tests) {                                               \
           free(utest_state.tests);                                             \
@@ -1443,7 +1444,7 @@ double utest_fabs(double d) {
     utest_uint64_t u;
   } both;
   both.d = d;
-  both.u &= 0x7fffffffffffffffu;
+  both.u &= ~((utest_uint64_t)1 << 63);
   return both.d;
 }
 
@@ -1456,8 +1457,8 @@ int utest_isnan(double d) {
     utest_uint64_t u;
   } both;
   both.d = d;
-  both.u &= 0x7fffffffffffffffu;
-  return both.u > 0x7ff0000000000000u;
+  both.u &= ~((utest_uint64_t)1 << 63);
+  return both.u > ((utest_uint64_t)0x7ff00000 << 32);
 }
 
 #ifdef __clang__
@@ -1729,16 +1730,16 @@ int utest_main(int argc, const char *const argv[]) {
   }
 
   printf("%s[==========]%s Running %" UTEST_PRIu64 " test cases.\n",
-         colours[GREEN], colours[RESET], UTEST_CAST(utest_uint64_t, ran_tests));
+         colours[GREEN], colours[RESET], UTEST_CAST(double, ran_tests));
 
   if (utest_state.output) {
     fprintf(utest_state.output, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
     fprintf(utest_state.output,
             "<testsuites tests=\"%" UTEST_PRIu64 "\" name=\"All\">\n",
-            UTEST_CAST(utest_uint64_t, ran_tests));
+            UTEST_CAST(double, ran_tests));
     fprintf(utest_state.output,
             "<testsuite name=\"Tests\" tests=\"%" UTEST_PRIu64 "\">\n",
-            UTEST_CAST(utest_uint64_t, ran_tests));
+            UTEST_CAST(double, ran_tests));
   }
 
   for (index = 0; index < utest_state.tests_length; index++) {
@@ -1818,28 +1819,31 @@ int utest_main(int argc, const char *const argv[]) {
 
       if (UTEST_TEST_FAILURE == result) {
         printf("%s[  FAILED  ]%s %s (%" UTEST_PRId64 "%s)\n", colours[RED],
-               colours[RESET], utest_state.tests[index].name, time,
+               colours[RESET], utest_state.tests[index].name,
+               UTEST_CAST(double, time),
                units[unit_index]);
       } else if (UTEST_TEST_SKIPPED == result) {
         printf("%s[  SKIPPED ]%s %s (%" UTEST_PRId64 "%s)\n", colours[YELLOW],
-               colours[RESET], utest_state.tests[index].name, time,
+               colours[RESET], utest_state.tests[index].name,
+               UTEST_CAST(double, time),
                units[unit_index]);
       } else {
         printf("%s[       OK ]%s %s (%" UTEST_PRId64 "%s)\n", colours[GREEN],
-               colours[RESET], utest_state.tests[index].name, time,
+               colours[RESET], utest_state.tests[index].name,
+               UTEST_CAST(double, time),
                units[unit_index]);
       }
     }
   }
 
   printf("%s[==========]%s %" UTEST_PRIu64 " test cases ran.\n", colours[GREEN],
-         colours[RESET], ran_tests);
+         colours[RESET], UTEST_CAST(double, ran_tests));
   printf("%s[  PASSED  ]%s %" UTEST_PRIu64 " tests.\n", colours[GREEN],
-         colours[RESET], ran_tests - failed - skipped);
+         colours[RESET], UTEST_CAST(double, ran_tests - failed - skipped));
 
   if (0 != skipped) {
     printf("%s[  SKIPPED ]%s %" UTEST_PRIu64 " tests, listed below:\n",
-           colours[YELLOW], colours[RESET], skipped);
+           colours[YELLOW], colours[RESET], UTEST_CAST(double, skipped));
     for (index = 0; index < skipped_testcases_length; index++) {
       printf("%s[  SKIPPED ]%s %s\n", colours[YELLOW], colours[RESET],
              utest_state.tests[skipped_testcases[index]].name);
@@ -1848,7 +1852,7 @@ int utest_main(int argc, const char *const argv[]) {
 
   if (0 != failed) {
     printf("%s[  FAILED  ]%s %" UTEST_PRIu64 " tests, listed below:\n",
-           colours[RED], colours[RESET], failed);
+           colours[RED], colours[RESET], UTEST_CAST(double, failed));
     for (index = 0; index < failed_testcases_length; index++) {
       printf("%s[  FAILED  ]%s %s\n", colours[RED], colours[RESET],
              utest_state.tests[failed_testcases[index]].name);


### PR DESCRIPTION
utest.h does not build for any ILP32 target under the warning settings projects
commonly enable, and in C++98 it does not build on NetBSD at all. Both come from
`<inttypes.h>`: `uint64_t` is `unsigned long` on LP64 but `unsigned long long` on
ILP32, and `long long` is not part of C90 or C++98.

```
utest.h:1446: error: integer constant is too large for 'unsigned long' [-Werror=long-long]
utest.h:      error: ISO C++98 does not support the 'll' gnu_printf length modifier
utest.h:1705: error: expected ')' before 'PRIu64'                  (NetBSD 10.1, C++98)
```

### What this does

**The constants.** `0x7fffffffffffffffu` and `0x7ff0000000000000u` are built in
the target type, so no oversized literal appears and every operand fits in 32 bits:

```c
both.u &= ~(UTEST_CAST(utest_uint64_t, 1) << 63);
return both.u > (UTEST_CAST(utest_uint64_t, 0x7ff00000) << 32);
```

**The format macros.** Following your review, `PRId64`/`PRIu64` stay the normal
path and the `double` fallback applies only where `ll` is genuinely unavailable —
ILP32 under C90 or C++98. Call sites pass their value through
`UTEST_INT64_ARG`/`UTEST_UINT64_ARG`, which expand to `(x)` on the normal path and
to a `double` cast on the fallback, so there is still one call site per message.
The MSVC `"I64d"`/`"I64u"` branch is untouched.

`_MSC_VER` is named explicitly in that condition. Windows is LLP64, so
`unsigned long` is 32 bits even on x64, and MSVC reports `__cplusplus` as
`199711L` without `/Zc:__cplusplus`. Without naming it, MSVC took the fallback in
all four x86/x64 × C/C++ configurations — precisely the silent change your review
was about.

**NetBSD.** `__STDC_FORMAT_MACROS` is defined before `<inttypes.h>`, which is what
that header documents. The macro is already defined in utest.h, but at line 274 on
`main` — 65 lines *after* the file's only `#include <inttypes.h>` at line 209, and
inside `#if defined(__linux__)`. It therefore cannot affect that include, and
NetBSD never reaches it. With the define in the right place no fallback is needed
there at all.

**macOS.** The three casts use `UTEST_CAST`; plain C casts tripped
`-Wold-style-cast` under the `-Weverything -Werror` this project applies to its
C++ sources, which is what the macOS jobs caught on the first revision.

### Verification

Which arm is actually live, checked at runtime per target rather than inferred
from a successful build — a fallback that triggers everywhere also compiles
everywhere, and `UTEST_PRIu64` is a string literal either way:

| Target | branch taken |
|---|---|
| x86_64, C gnu89/c99, C++ gnu++98/c++17 | native `"lu"`/`"ld"` |
| i386, C gnu89 and C++ gnu++98 | **fallback** `".0f"` |
| i386, C c99 and C++ c++11 | native `"llu"`/`"lld"` |
| MSVC 19.44, x86 and x64, C and C++ | native `"llu"`/`"lld"` |
| AIX 7.3 / POWER10, 32- and 64-bit | native `"llu"`/`"lu"` |

On AIX, measured one variant at a time so the result is attributable to a single
change:

| utest.h | AIX 64-bit | AIX 32-bit |
|---|---|---|
| upstream `main` | `#error Unsupported platform!` | `#error Unsupported platform!` |
| this PR only | `#error Unsupported platform!` | `#error Unsupported platform!` |
| #189 only | 441 / 441 | oversized constants, `ll` modifier |
| **both** | **441 / 441** | **441 / 441** |

**On AIX this PR alone changes nothing**, and I would rather be precise about
that than claim more: `utest_ns()` rejects the platform before the 32-bit problems
are reached, so #189 gates everything there. On i386 Linux, where no platform
branch is involved, this PR alone takes the build from failing to 441 / 441.

Re-measured after the rework on the same POWER10 machine: **443 / 443 at both word
sizes** with #189 and this PR, and the build still fails 32-bit with #189 alone, so
the control still bites. 443 rather than 441 because the vendoring project has
gained two tests since.

Nothing changed where it already worked: x86_64 Linux glibc and musl, MSVC 19.44
x86 and x64 with both CRTs, clang with UBSan, and compile-clean on NetBSD 9.4,
OpenBSD 7.9 and FreeBSD 14.3. Test counts come from a project that vendors this
header, so the same file is exercised across all of those targets.
