### PR TITLE
Support AIX in utest_ns()

### DIFF
--- a/utest.h
+++ b/utest.h
@@ -198,6 +198,9 @@ UTEST_C_FUNC __declspec(dllimport) int __stdcall QueryPerformanceFrequency(
 #define UTEST_USE_CLOCKGETTIME
 #endif
 
+#elif defined(_AIX)
+#include <time.h>
+
 #elif defined(__APPLE__)
 #include <time.h>
 #endif
@@ -367,6 +370,10 @@ static UTEST_INLINE utest_int64_t utest_ns(void) {
   syscall(SYS_clock_gettime, cid, &ts);
 #endif
 #endif
+  return UTEST_CAST(utest_int64_t, ts.tv_sec) * 1000 * 1000 * 1000 + ts.tv_nsec;
+#elif defined(_AIX)
+  struct timespec ts = {0, 0};
+  clock_gettime(CLOCK_REALTIME, &ts);
   return UTEST_CAST(utest_int64_t, ts.tv_sec) * 1000 * 1000 * 1000 + ts.tv_nsec;
 #elif __EMSCRIPTEN__
   return emscripten_performance_now() * 1000000.0;


### PR DESCRIPTION
AIX matches none of the platforms `utest_ns()` knows, so it falls through to
`#error Unsupported platform!` and nothing builds there. `grep -c _AIX utest.h`
returns 0.

It cannot simply join the Linux/BSD branch. That one calls
`timespec_get(&ts, TIME_UTC)` when `__STDC_VERSION__ >= 201112L`, and AIX 7.2
does not have it. From the system's own header:

```
$ grep -nE "timespec_get|clock_gettime|CLOCK_REALTIME" /usr/include/time.h
231:#define CLOCK_REALTIME           ((clockid_t) 9)
232:#define CLOCK_MONOTONIC          ((clockid_t) 10)
238:extern int clock_gettime(clockid_t, struct timespec *);
```

`clock_gettime` is there; `timespec_get` and `TIME_UTC` are not. Adding `_AIX`
to the existing list would therefore compile in C89 and C99 and fail in C11 —
which is exactly the kind of thing that only shows up later. So AIX gets its
own branch, using `clock_gettime` unconditionally.

### Verification

Measured on **AIX 7.2 TL04 (7200-04-02-2027) on POWER8**, GCC 13.3.0. With this
applied and `-maix64`, the test suite of a project that vendors utest.h builds
and passes **441 of 441**. Without it the build stops at the `#error`.

No other platform is touched — the change is two `#elif` blocks, +7 lines.

Building on AIX in GCC's *default* 32-bit mode additionally needs the fixes in
#188, which are unrelated to AIX and also affect i386 Linux. Either PR
stands on its own; both are needed for 32-bit AIX.