### PR TITLE
Fix the test filter dropping tests it should run

### DIFF
--- a/test/main.c
+++ b/test/main.c
@@ -218,4 +218,50 @@ UTEST(utest_cmdline, list_tests_same_line_sorted_by_index) {
 }
 #endif
 
+/* utest_should_filter_test returns 0 to run a test and 1 to skip it. These
+   call it directly rather than spawning a binary, so they also run on MinGW. */
+
+UTEST(utest_filter, exact_name) {
+  EXPECT_EQ(0, utest_should_filter_test("foo.bar", "foo.bar"));
+  EXPECT_EQ(1, utest_should_filter_test("foo.baz", "foo.bar"));
+}
+
+UTEST(utest_filter, no_filter_runs_everything) {
+  EXPECT_EQ(0, utest_should_filter_test(UTEST_NULL, "foo.bar"));
+  EXPECT_EQ(0, utest_should_filter_test("*", "foo.bar"));
+}
+
+UTEST(utest_filter, leading_and_trailing_wildcards) {
+  EXPECT_EQ(0, utest_should_filter_test("foo.*", "foo.bar"));
+  EXPECT_EQ(0, utest_should_filter_test("*bar", "foo.bar"));
+  EXPECT_EQ(0, utest_should_filter_test("*.ba*", "foo.bar"));
+  EXPECT_EQ(1, utest_should_filter_test("*baz*", "foo.bar"));
+}
+
+/* A wildcard may stand for nothing, so a trailing one must still match when
+   the literal part reached the end of the name. */
+UTEST(utest_filter, trailing_wildcard_matches_empty_remainder) {
+  EXPECT_EQ(0, utest_should_filter_test("*bar*", "foo.bar"));
+  EXPECT_EQ(0, utest_should_filter_test("foo.bar*", "foo.bar"));
+  EXPECT_EQ(0, utest_should_filter_test("*foo.bar*", "foo.bar"));
+  EXPECT_EQ(0, utest_should_filter_test("*bar**", "foo.bar"));
+  EXPECT_EQ(0, utest_should_filter_test("*", ""));
+}
+
+/* The same shape, but the filter still has literal characters left over. */
+UTEST(utest_filter, literals_after_an_exhausted_name_do_not_match) {
+  EXPECT_EQ(1, utest_should_filter_test("*bar*baz", "foo.bar"));
+  EXPECT_EQ(1, utest_should_filter_test("foo.bar.", "foo.bar"));
+}
+
+/* A wildcard must be able to give characters back when the first place its
+   literal matched turns out to be the wrong one. */
+UTEST(utest_filter, wildcard_backtracks) {
+  EXPECT_EQ(0, utest_should_filter_test("*o.b*", "foo.bar"));
+  EXPECT_EQ(0, utest_should_filter_test("*a*a*", "banana"));
+  EXPECT_EQ(0, utest_should_filter_test("*ana*na", "banana"));
+  EXPECT_EQ(0, utest_should_filter_test("*oo*ar", "foo.bar"));
+  EXPECT_EQ(1, utest_should_filter_test("*oo*az", "foo.bar"));
+}
+
 UTEST_MAIN()

--- a/utest.h
+++ b/utest.h
@@ -1482,58 +1482,34 @@ UTEST_WEAK int utest_should_filter_test(const char *filter,
     const char *filter_cur = filter;
     const char *testcase_cur = testcase;
     const char *filter_wildcard = UTEST_NULL;
+    const char *testcase_resume = UTEST_NULL;
 
-    while (('\0' != *filter_cur) && ('\0' != *testcase_cur)) {
-      if ('*' == *filter_cur) {
-        /* store the position of the wildcard */
-        filter_wildcard = filter_cur;
-
-        /* skip the wildcard character */
+    while ('\0' != *testcase_cur) {
+      if (('*' != *filter_cur) && (*filter_cur == *testcase_cur)) {
+        /* literal match, consume a character from each */
         filter_cur++;
-
-        while (('\0' != *filter_cur) && ('\0' != *testcase_cur)) {
-          if ('*' == *filter_cur) {
-            /*
-               we found another wildcard (filter is something like *foo*) so we
-               exit the current loop, and return to the parent loop to handle
-               the wildcard case
-            */
-            break;
-          } else if (*filter_cur != *testcase_cur) {
-            /* otherwise our filter didn't match, so reset it */
-            filter_cur = filter_wildcard;
-          }
-
-          /* move testcase along */
-          testcase_cur++;
-
-          /* move filter along */
-          filter_cur++;
-        }
-
-        if (('\0' == *filter_cur) && ('\0' == *testcase_cur)) {
-          return 0;
-        }
-
-        /* if the testcase has been exhausted, we don't have a match! */
-        if ('\0' == *testcase_cur) {
-          return 1;
-        }
+        testcase_cur++;
+      } else if ('*' == *filter_cur) {
+        /* remember where to resume should the rest fail to match */
+        filter_wildcard = filter_cur++;
+        testcase_resume = testcase_cur;
+      } else if (UTEST_NULL != filter_wildcard) {
+        /* let the last wildcard swallow one more character and retry */
+        filter_cur = filter_wildcard + 1;
+        testcase_resume++;
+        testcase_cur = testcase_resume;
       } else {
-        if (*testcase_cur != *filter_cur) {
-          /* test case doesn't match filter */
-          return 1;
-        } else {
-          /* move our filter and testcase forward */
-          testcase_cur++;
-          filter_cur++;
-        }
+        /* test case doesn't match filter */
+        return 1;
       }
     }
 
-    if (('\0' != *filter_cur) ||
-        (('\0' != *testcase_cur) &&
-         ((filter == filter_cur) || ('*' != filter_cur[-1])))) {
+    /* a wildcard may stand for nothing, so any left over still match */
+    while ('*' == *filter_cur) {
+      filter_cur++;
+    }
+
+    if ('\0' != *filter_cur) {
       /* we have a mismatch! */
       return 1;
     }


### PR DESCRIPTION
`utest_should_filter_test` gets two things wrong. Both fail the same way: the
test is silently skipped, and nothing is reported — the run just comes back
green with fewer tests than you asked for.

### A trailing wildcard never matches the empty remainder

--filter=*bar    runs foo.bar
--filter=ba    runs foo.bar
--filter=bar   does not

Once the name is exhausted, a wildcard still left in the filter is treated as a mismatch rather than as standing for nothing. It bites in two places: when the inner wildcard loop runs out of name, and when the outer loop does.

### A wildcard cannot give characters back

On a mismatch the filter position is reset to the wildcard, but the name position is not, so the retry resumes partway through the name instead of one character on from where the attempt began. This is not an edge case:

--filter=o.b   does not match foo.bar

### The change

Replaced with the usual iterative glob match — remember the wildcard and the position to resume from, and on a mismatch let the wildcard swallow one more character. It handles both defects, and `utest.h` comes out **24 lines shorter** than before.

Measured over 21 filter/name pairs: the current implementation answers 6 of them wrongly, the replacement none. Patching only the trailing-wildcard case still leaves 3 wrong, which is why this replaces the function rather than guarding it.

### Tests

Six tests covering exact names, leading and trailing wildcards, literals after an exhausted name, and backtracking. They call the function directly instead of spawning a binary, so unlike the `utest_cmdline` suite they also run under MinGW.

Five of the six fail against the current implementation — checked, so they are known to have teeth rather than assumed to.

| | |
|---|---|
| new tests, current header | red |
| new tests, this change | green |
| whole suite, untouched `main` | green, 2161 |
| whole suite, this change | green, 2167 |

Independent of #188 and #189; applies to `main` on its own.